### PR TITLE
Redirect insecure connections to the playground

### DIFF
--- a/content/playground.html
+++ b/content/playground.html
@@ -70,6 +70,13 @@
 <script>
 window.onload = function() {
 
+  var link = document.createElement('a');
+  link.setAttribute('href', window.location.href);
+  if (link.protocol == 'http:' && link.hostname == 'developers.strava.com') {
+    link.protocol = 'https:';
+    window.location = link.href;
+  }
+  
   // Build a system
   // To run the authentication locally, change the oauth2RedirectUrl
   // to 'http://localhost:1313/oauth2-redirect/'


### PR DESCRIPTION
When the playground is loaded in production over HTTP, Swagger's UI code fails to fetch the definitions of the models because they are referenced using HTTPS. This works locally because the connection is not encrypted but in production, unless the playground page is loaded over HTTPS to begin with, this will fail.

This change is a horrible hack to redirect the user to the secure playground page when we detect they they are on the production site and that they have loaded the page using HTTP rather than HTTPS