### PR TITLE
[CP-1731] Revise definition of `resource_state` on API docs

### DIFF
--- a/swagger/athlete.json.mustache
+++ b/swagger/athlete.json.mustache
@@ -70,7 +70,7 @@
         "properties": {
           "resource_state": {
             "type": "integer",
-            "description": "Resource state"
+            "description": "Resource state, indicates level of detail. Possible values: 1 -> \"meta\", 2 -> \"summary\", 3 -> \"detail\""
           },
           "firstname": {
             "type": "string",

--- a/swagger/club.json.mustache
+++ b/swagger/club.json.mustache
@@ -95,7 +95,7 @@
       },
       "resource_state": {
         "type": "integer",
-        "description": "Resource state"
+        "description": "Resource state, indicates level of detail. Possible values: 1 -> \"meta\", 2 -> \"summary\", 3 -> \"detail\""
       },
       "name": {
         "type": "string",

--- a/swagger/gear.json.mustache
+++ b/swagger/gear.json.mustache
@@ -35,7 +35,7 @@
       },
       "resource_state": {
         "type": "integer",
-        "description": "Resource state"
+        "description": "Resource state, indicates level of detail. Possible values: 2 -> \"summary\", 3 -> \"detail\""
       },
       "primary": {
         "type": "boolean",


### PR DESCRIPTION
Background:
This is the developers.strava.com counterpart to [CP-1719](https://strava.atlassian.net/browse/CP-1719). Developers were getting confused about the possible values and meaning of the `resource_state` attribute, so we want to be more explicit about what it means.

Solution:
Update the API documentation to reflect the possible values for resource_state.

Result:
developers.strava.com has updated `resource_state` documentation.

Completes [CP-1731](https://strava.atlassian.net/browse/CP-1731)

![screen shot 2017-10-30 at 5 49 51 pm](https://user-images.githubusercontent.com/13637569/32202536-c12647a8-bd9a-11e7-9fb4-5809eb5d923c.png)
