### PR TITLE
Update age and weight bands in documentation

### DIFF
--- a/swagger/swagger.json.mustache
+++ b/swagger/swagger.json.mustache
@@ -523,14 +523,14 @@
             "in": "query",
             "description": "Enables filtering of entries by a given age-group",
             "type": "string",
-            "enum": ["0_24", "25_34", "35_44", "45_54", "55_64", "65_plus"]
+            "enum": ["0_19", "20_24", "25_34", "35_44", "45_54", "55_64", "65_69", "70_74", "75_plus"]
           },
           {
             "name": "weight_class",
             "in": "query",
             "description": "Enables filtering of entries by a given weight class",
             "type": "string",
-            "enum": ["0_124", "125_149", "150_164", "165_179", "180_199", "200_plus", "0_54", "55_64", "65_74", "75_84", "85_94", "95_plus"]
+            "enum": ["0_74", "75_99", "100_124", "125_149", "150_164", "165_179", "180_199", "200_224", "225_249", "250_plus", "0_34", "35_44", "45_54", "55_64", "65_74", "75_84", "85_94", "95_104", "105_114", "115_plus"]
           },
           {
             "name": "following",


### PR DESCRIPTION
I noticed that the age and weight bands in the live Strava site have been updated and are different from the ones in the API docs. These changes update the docs to reflect reality. 