### PR TITLE
[CP-1710] Changing some types to be int64, strings and fixing some typos

### DIFF
--- a/specs/java/compile.sh
+++ b/specs/java/compile.sh
@@ -4,4 +4,4 @@ set -e
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $BASEDIR/generate.sh $1 $BASEDIR/smoke/generated
-mvn --file $BASEDIR/smoke/generated/pom.xml compile
+mvn -e --file $BASEDIR/smoke/generated/pom.xml compile

--- a/specs/java/smoke/tests/src/test/java/com/strava/api/v3/services/StreamsApiTest.java
+++ b/specs/java/smoke/tests/src/test/java/com/strava/api/v3/services/StreamsApiTest.java
@@ -21,7 +21,7 @@ public class StreamsApiTest extends ApiTest {
   public void testGetActivityStream() throws InterruptedException {
     CollectionFormats.CSVParams keys = new CollectionFormats.CSVParams("altitude", "distance");
     TestObserver<StreamSet> observer = streamsApi.getActivityStreams(
-        1196721622, keys, true).test().await();
+        1196721622L, keys, true).test().await();
     observer.assertNoErrors();
     StreamSet streams = observer.values().get(0);
     assertNotNull(streams.getDistance());
@@ -32,7 +32,7 @@ public class StreamsApiTest extends ApiTest {
   public void testGetSegmentStream() throws InterruptedException {
     CollectionFormats.CSVParams keys = new CollectionFormats.CSVParams("altitude", "latlng");
     TestObserver<StreamSet> observer = streamsApi.getSegmentStreams(
-        8109834, keys, true).test().await();
+        8109834L, keys, true).test().await();
     observer.assertNoErrors();
     StreamSet streams = observer.values().get(0);
     assertNotNull(streams.getLatlng());

--- a/specs/java/test.sh
+++ b/specs/java/test.sh
@@ -4,4 +4,4 @@ set -e
 BASEDIR=$(dirname "$0")
 
 $BASEDIR/generate.sh $1 $BASEDIR/smoke/generated
-mvn -X -DaccessToken=$2 --file $BASEDIR/smoke/pom.xml test
+mvn -e -DaccessToken=$2 --file $BASEDIR/smoke/pom.xml test

--- a/specs/java/test.sh
+++ b/specs/java/test.sh
@@ -4,4 +4,4 @@ set -e
 BASEDIR=$(dirname "$0")
 
 $BASEDIR/generate.sh $1 $BASEDIR/smoke/generated
-mvn -DaccessToken=$2 --file $BASEDIR/smoke/pom.xml test
+mvn -X -DaccessToken=$2 --file $BASEDIR/smoke/pom.xml test

--- a/swagger/activity.json.mustache
+++ b/swagger/activity.json.mustache
@@ -77,7 +77,8 @@
             "description": "The identifier provided at upload time"
           },
           "upload_id": {
-            "type": "string",
+            "type": "integer",
+            "format": "int64",
             "description": "The identifier of the upload that resulted in this activity"
           },
           "athlete": {

--- a/swagger/activity.json.mustache
+++ b/swagger/activity.json.mustache
@@ -77,7 +77,7 @@
             "description": "The identifier provided at upload time"
           },
           "upload_id": {
-            "type": "integer",
+            "type": "string",
             "description": "The identifier of the upload that resulted in this activity"
           },
           "athlete": {
@@ -213,6 +213,7 @@
     "properties": {
       "id": {
         "type": "integer",
+        "format": "int64",
         "description": "The unique identifier of the activity"
       }
     }

--- a/swagger/athlete.json.mustache
+++ b/swagger/athlete.json.mustache
@@ -138,7 +138,6 @@
     "properties": {
       "id": {
         "type": "integer",
-        "format": "int64",
         "description": "The unique identifier of the athlete"
       }
     }

--- a/swagger/athlete.json.mustache
+++ b/swagger/athlete.json.mustache
@@ -138,6 +138,7 @@
     "properties": {
       "id": {
         "type": "integer",
+        "format": "int64",
         "description": "The unique identifier of the athlete"
       }
     }

--- a/swagger/club.json.mustache
+++ b/swagger/club.json.mustache
@@ -108,6 +108,7 @@
     "properties": {
       "id": {
         "type": "integer",
+        "format": "int64",
         "description": "The unique identifier of this announcement."
       },
       "club_id": {

--- a/swagger/club.json.mustache
+++ b/swagger/club.json.mustache
@@ -103,31 +103,6 @@
       }
     }
   },
-  "ClubAnnouncement": {
-    "type": "object",
-    "properties": {
-      "id": {
-        "type": "integer",
-        "description": "The unique identifier of this announcement."
-      },
-      "club_id": {
-        "type": "integer",
-        "description": "The unique identifier of the club this announcements was made in."
-      },
-      "athlete": {
-        "$ref": "{{reference_prefix}}/athlete.json#/SummaryAthlete"
-      },
-      "created_at": {
-        "type": "string",
-        "format": "date-time",
-        "description": "The time at which this announcement was created."
-      },
-      "message": {
-        "type": "string",
-        "description": "The content of this announcement"
-      }
-    }
-  },
   "MembershipApplication": {
     "type": "object",
     "properties": {

--- a/swagger/club.json.mustache
+++ b/swagger/club.json.mustache
@@ -108,7 +108,6 @@
     "properties": {
       "id": {
         "type": "integer",
-        "format": "int64",
         "description": "The unique identifier of this announcement."
       },
       "club_id": {

--- a/swagger/comment.json.mustache
+++ b/swagger/comment.json.mustache
@@ -4,10 +4,12 @@
     "properties": {
       "id": {
         "type": "integer",
+        "format": "int64",
         "description": "The unique identifier of this comment"
       },
       "activity_id": {
         "type": "integer",
+        "format": "int64",
         "description": "The identifier of the activity this comment is related to"
       },
       "text": {

--- a/swagger/photo.json.mustache
+++ b/swagger/photo.json.mustache
@@ -10,7 +10,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           "source": {
             "type": "integer"

--- a/swagger/segment.json.mustache
+++ b/swagger/segment.json.mustache
@@ -49,6 +49,7 @@
     "properties": {
       "id": {
         "type": "integer",
+        "format": "int64",
         "description": "The unique identifier of this segment"
       },
       "name": {
@@ -134,6 +135,7 @@
     "properties": {
       "id": {
         "type": "integer",
+        "format": "int64",
         "description": "The unique identifier of this segment"
       },
       "name": {

--- a/swagger/segment_leaderboard.json.mustache
+++ b/swagger/segment_leaderboard.json.mustache
@@ -25,7 +25,6 @@
       },
       "athlete_id": {
         "type": "integer",
-        "format": "int64",
         "description": "The unique identifier of the athlete"
       },
       "athlete_gender": {

--- a/swagger/segment_leaderboard.json.mustache
+++ b/swagger/segment_leaderboard.json.mustache
@@ -66,6 +66,7 @@
       },
       "activity_id": {
         "type": "integer",
+        "format": "int64",
         "description": "The unique identifier of the activity associated with this entry"
       },
       "effort_id": {

--- a/swagger/segment_leaderboard.json.mustache
+++ b/swagger/segment_leaderboard.json.mustache
@@ -25,6 +25,7 @@
       },
       "athlete_id": {
         "type": "integer",
+        "format": "int64",
         "description": "The unique identifier of the athlete"
       },
       "athlete_gender": {

--- a/swagger/swagger.json.mustache
+++ b/swagger/swagger.json.mustache
@@ -847,7 +847,8 @@
             "in": "path",
             "description": "The identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "name": "body",
@@ -1576,7 +1577,7 @@
             "in": "path",
             "description": "The identifier of the gear.",
             "required": true,
-            "type": "integer"
+            "type": "string"
           }
         ],
         "tags": [
@@ -1928,7 +1929,8 @@
             "in": "path",
             "description": "The identifier of the segment.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "name": "keys",

--- a/swagger/swagger.json.mustache
+++ b/swagger/swagger.json.mustache
@@ -413,7 +413,8 @@
             "in": "path",
             "description": "The identifier of the segment.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "tags": [
@@ -481,7 +482,8 @@
             "in": "path",
             "description": "The identifier of the segment to star.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "tags": [
@@ -514,7 +516,8 @@
             "in": "path",
             "description": "The identifier of the segment to get leaderboards for.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "name": "gender",
@@ -598,7 +601,8 @@
             "in": "path",
             "description": "The identifier of the segment.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "$ref": "#/parameters/page"

--- a/swagger/swagger.json.mustache
+++ b/swagger/swagger.json.mustache
@@ -58,8 +58,7 @@
             "in": "path",
             "description": "The identifier of the athlete.",
             "required": true,
-            "type": "integer",
-            "format": "int64"
+            "type": "integer"
           }
         ],
         "tags": [
@@ -92,8 +91,7 @@
             "in": "path",
             "description": "The identifier of the athlete.",
             "required": true,
-            "type": "integer",
-            "format": "int64"
+            "type": "integer"
           },
           {
             "$ref": "#/parameters/page"
@@ -135,8 +133,7 @@
             "in": "path",
             "description": "The identifier of the athlete.",
             "required": true,
-            "type": "integer",
-            "format": "int64"
+            "type": "integer"
           },
           {
             "$ref": "#/parameters/page"
@@ -178,8 +175,7 @@
             "in": "path",
             "description": "The identifier of the athlete.",
             "required": true,
-            "type": "integer",
-            "format": "int64"
+            "type": "integer"
           },
           {
             "$ref": "#/parameters/page"
@@ -221,8 +217,7 @@
             "in": "path",
             "description": "The identifier of the athlete.",
             "required": true,
-            "type": "integer",
-            "format": "int64"
+            "type": "integer"
           },
           {
             "$ref": "#/parameters/page"
@@ -1643,8 +1638,7 @@
             "in": "path",
             "description": "The identifier of the athlete.",
             "required": true,
-            "type": "integer",
-            "format": "int64"
+            "type": "integer"
           },
           {
             "$ref": "#/parameters/page"
@@ -1762,7 +1756,8 @@
             "in": "path",
             "description": "The identifier of the upload.",
             "required": true,
-            "type": "string"
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "tags": [

--- a/swagger/swagger.json.mustache
+++ b/swagger/swagger.json.mustache
@@ -58,7 +58,8 @@
             "in": "path",
             "description": "The identifier of the athlete.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "tags": [
@@ -91,7 +92,8 @@
             "in": "path",
             "description": "The identifier of the athlete.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "$ref": "#/parameters/page"
@@ -133,7 +135,8 @@
             "in": "path",
             "description": "The identifier of the athlete.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "$ref": "#/parameters/page"
@@ -175,7 +178,8 @@
             "in": "path",
             "description": "The identifier of the athlete.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "$ref": "#/parameters/page"
@@ -217,7 +221,8 @@
             "in": "path",
             "description": "The identifier of the athlete.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "$ref": "#/parameters/page"
@@ -507,7 +512,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The identifier of the segment to get leaderbaords for.",
+            "description": "The identifier of the segment to get leaderboards for.",
             "required": true,
             "type": "integer"
           },
@@ -541,7 +546,7 @@
           {
             "name": "club_id",
             "in": "query",
-            "description": "Enables filtering of entries by the membership of a given clu",
+            "description": "Enables filtering of entries by the membership of a given club",
             "type": "integer"
           },
           {
@@ -800,7 +805,8 @@
             "in": "path",
             "description": "The identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "name": "include_all_efforts",
@@ -875,7 +881,8 @@
             "in": "path",
             "description": "The identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "tags": [
@@ -1060,7 +1067,8 @@
             "in": "path",
             "description": "The unique identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "$ref": "#/parameters/page"
@@ -1102,7 +1110,8 @@
             "in": "path",
             "description": "The identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "tags": [
@@ -1138,7 +1147,8 @@
             "in": "path",
             "description": "The identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "tags": [
@@ -1174,7 +1184,8 @@
             "in": "path",
             "description": "The identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "$ref": "#/parameters/page"
@@ -1216,7 +1227,8 @@
             "in": "path",
             "description": "The identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "$ref": "#/parameters/page"
@@ -1626,7 +1638,8 @@
             "in": "path",
             "description": "The identifier of the athlete.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "$ref": "#/parameters/page"
@@ -1744,7 +1757,7 @@
             "in": "path",
             "description": "The identifier of the upload.",
             "required": true,
-            "type": "integer"
+            "type": "string"
           }
         ],
         "tags": [
@@ -1777,7 +1790,8 @@
             "in": "path",
             "description": "The identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "name": "keys",

--- a/swagger/upload.json.mustache
+++ b/swagger/upload.json.mustache
@@ -3,7 +3,8 @@
     "type": "object",
     "properties": {
       "id": {
-        "type": "string",
+        "type": "integer",
+        "format": "int64",
         "description": "The unique identifier of the upload"
       },
       "external_id": {

--- a/swagger/upload.json.mustache
+++ b/swagger/upload.json.mustache
@@ -3,7 +3,7 @@
     "type": "object",
     "properties": {
       "id": {
-        "type": "integer",
+        "type": "string",
         "description": "The unique identifier of the upload"
       },
       "external_id": {
@@ -20,6 +20,7 @@
       },
       "activity_id": {
         "type": "integer",
+        "format": "int64",
         "description": "The identifier of the activity this upload resulted into"
       }
     }


### PR DESCRIPTION
Implements the `developers.strava.com` portion of [CP-1710](https://strava.atlassian.net/browse/CP-1710)

A few notes/questions:

- I moved the things to `int64` that we definitely model as long in the Android app and that seemed like they could theoretically max out at some point. In some spots it may be overkill, please comment as such.
- I wasn't sure about `routes id` or `segment id`. They _are_ crowdsourced, seems unlikely that we'd have > 2 billion of either, right? I made `segment_id` a long anyway, just in case (I know there's a lot of noise out there).