### PR TITLE
[CP-1710] Switches several identifiers to int64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,8 @@ RUN scripts/generate_swagger_spec.sh $MODE static/swagger
 # built locally
 RUN scripts/generate_swagger_spec.sh local /tmp/swagger
 RUN java -classpath codegen/target/static-html-codegen-1.0.0.jar:/usr/bin/swagger-codegen-cli-2.2.3.jar \
-  io.swagger.codegen.Codegen \
+  io.swagger.codegen.SwaggerCodegen \
+  generate \
   --input-spec /tmp/swagger/swagger.json \
   --config config/strava-html.json \
   --lang strava-html \

--- a/specs/java/compile.sh
+++ b/specs/java/compile.sh
@@ -3,5 +3,6 @@ set -e
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+rm -Rf $BASEDIR/smoke/generated
 $BASEDIR/generate.sh $1 $BASEDIR/smoke/generated
-mvn --file $BASEDIR/smoke/generated/pom.xml compile
+mvn -e --file $BASEDIR/smoke/generated/pom.xml compile

--- a/specs/java/generate.sh
+++ b/specs/java/generate.sh
@@ -10,8 +10,8 @@ TMP_DIR="$( mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir' )"
 API_SPECIFICATION=$TMP_DIR/apispec
 $BASEDIR/../../scripts/generate_swagger_spec.sh local $API_SPECIFICATION
 
-java -classpath $1 \
-  io.swagger.codegen.Codegen \
+java -jar $1 \
+  generate \
   --input-spec $API_SPECIFICATION/swagger.json \
   --config $BASEDIR/config.json \
   --lang java \

--- a/specs/java/smoke/tests/src/test/java/com/strava/api/v3/services/StreamsApiTest.java
+++ b/specs/java/smoke/tests/src/test/java/com/strava/api/v3/services/StreamsApiTest.java
@@ -21,7 +21,7 @@ public class StreamsApiTest extends ApiTest {
   public void testGetActivityStream() throws InterruptedException {
     CollectionFormats.CSVParams keys = new CollectionFormats.CSVParams("altitude", "distance");
     TestObserver<StreamSet> observer = streamsApi.getActivityStreams(
-        1196721622, keys, true).test().await();
+        1196721622L, keys, true).test().await();
     observer.assertNoErrors();
     StreamSet streams = observer.values().get(0);
     assertNotNull(streams.getDistance());
@@ -32,7 +32,7 @@ public class StreamsApiTest extends ApiTest {
   public void testGetSegmentStream() throws InterruptedException {
     CollectionFormats.CSVParams keys = new CollectionFormats.CSVParams("altitude", "latlng");
     TestObserver<StreamSet> observer = streamsApi.getSegmentStreams(
-        8109834, keys, true).test().await();
+        8109834L, keys, true).test().await();
     observer.assertNoErrors();
     StreamSet streams = observer.values().get(0);
     assertNotNull(streams.getLatlng());

--- a/specs/java/test.sh
+++ b/specs/java/test.sh
@@ -4,4 +4,4 @@ set -e
 BASEDIR=$(dirname "$0")
 
 $BASEDIR/generate.sh $1 $BASEDIR/smoke/generated
-mvn -DaccessToken=$2 --file $BASEDIR/smoke/pom.xml test
+mvn -e -DaccessToken=$2 --file $BASEDIR/smoke/pom.xml test

--- a/swagger/activity.json.mustache
+++ b/swagger/activity.json.mustache
@@ -78,6 +78,7 @@
           },
           "upload_id": {
             "type": "integer",
+            "format": "int64",
             "description": "The identifier of the upload that resulted in this activity"
           },
           "athlete": {
@@ -213,6 +214,7 @@
     "properties": {
       "id": {
         "type": "integer",
+        "format": "int64",
         "description": "The unique identifier of the activity"
       }
     }

--- a/swagger/comment.json.mustache
+++ b/swagger/comment.json.mustache
@@ -4,10 +4,12 @@
     "properties": {
       "id": {
         "type": "integer",
+        "format": "int64",
         "description": "The unique identifier of this comment"
       },
       "activity_id": {
         "type": "integer",
+        "format": "int64",
         "description": "The identifier of the activity this comment is related to"
       },
       "text": {

--- a/swagger/photo.json.mustache
+++ b/swagger/photo.json.mustache
@@ -10,7 +10,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           "source": {
             "type": "integer"

--- a/swagger/segment.json.mustache
+++ b/swagger/segment.json.mustache
@@ -49,6 +49,7 @@
     "properties": {
       "id": {
         "type": "integer",
+        "format": "int64",
         "description": "The unique identifier of this segment"
       },
       "name": {
@@ -134,6 +135,7 @@
     "properties": {
       "id": {
         "type": "integer",
+        "format": "int64",
         "description": "The unique identifier of this segment"
       },
       "name": {

--- a/swagger/segment_leaderboard.json.mustache
+++ b/swagger/segment_leaderboard.json.mustache
@@ -66,6 +66,7 @@
       },
       "activity_id": {
         "type": "integer",
+        "format": "int64",
         "description": "The unique identifier of the activity associated with this entry"
       },
       "effort_id": {

--- a/swagger/swagger.json.mustache
+++ b/swagger/swagger.json.mustache
@@ -408,7 +408,8 @@
             "in": "path",
             "description": "The identifier of the segment.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "tags": [
@@ -476,7 +477,8 @@
             "in": "path",
             "description": "The identifier of the segment to star.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "tags": [
@@ -509,7 +511,8 @@
             "in": "path",
             "description": "The identifier of the segment to get leaderbaords for.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "name": "gender",
@@ -542,7 +545,8 @@
             "name": "club_id",
             "in": "query",
             "description": "Enables filtering of entries by the membership of a given clu",
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "name": "date_range",
@@ -800,7 +804,8 @@
             "in": "path",
             "description": "The identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "name": "include_all_efforts",
@@ -837,7 +842,8 @@
             "in": "path",
             "description": "The identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "name": "body",
@@ -875,7 +881,8 @@
             "in": "path",
             "description": "The identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "tags": [
@@ -1060,7 +1067,8 @@
             "in": "path",
             "description": "The unique identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "$ref": "#/parameters/page"
@@ -1102,7 +1110,8 @@
             "in": "path",
             "description": "The identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "tags": [
@@ -1174,7 +1183,8 @@
             "in": "path",
             "description": "The identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "$ref": "#/parameters/page"
@@ -1744,7 +1754,8 @@
             "in": "path",
             "description": "The identifier of the upload.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "tags": [
@@ -1777,7 +1788,8 @@
             "in": "path",
             "description": "The identifier of the activity.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "name": "keys",
@@ -1910,7 +1922,8 @@
             "in": "path",
             "description": "The identifier of the segment.",
             "required": true,
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           {
             "name": "keys",

--- a/swagger/upload.json.mustache
+++ b/swagger/upload.json.mustache
@@ -4,6 +4,7 @@
     "properties": {
       "id": {
         "type": "integer",
+        "format": "int64",
         "description": "The unique identifier of the upload"
       },
       "external_id": {
@@ -20,6 +21,7 @@
       },
       "activity_id": {
         "type": "integer",
+        "format": "int64",
         "description": "The identifier of the activity this upload resulted into"
       }
     }


### PR DESCRIPTION
This change updates the type of several identifiers to be int64: activites, segments, uploads in particular.

Along with this, it makes some updates to the test harness and the generation of the documentation and test code:

- we have been using `io.swagger.codegen.Codegen` as a main class to generate both the documentation and the test Java code. As it turns out, this class doesn't fail loudly and invoking it directly will not print an error message and not return an error code. Instead, we should call `io.swagger.codegen.SwaggerCodegen`, which is the main class invoked by the Swagger CLI.
- when the Docker image is built after having run the tests locally, it main contain the generated Java code at `specs/java/generated`. This is because we `COPY` the entire source tree and that the tree may be unclean. We should revisit this but in the meantime, a stopgap measure should be to simply delete the whole generated source before regenerating it.