### PR TITLE
[CP-1772] Add rate limits page

### DIFF
--- a/content/docs/rate-limiting.md
+++ b/content/docs/rate-limiting.md
@@ -1,0 +1,67 @@
+# Rate limiting
+
+Strava API usage is limited on a per-application basis using both a 15-minute and daily request limit.
+The default rate limit allows 600 requests every 15 minutes, with up to 30,000 requests per day.
+This limit allows applications to make 40 requests per minute for about half the day.
+As an application grows, its rate limit may need to be adjusted.
+To request an adjustment, email api-rate-limits@strava.com.
+
+An application's 15-minute limit is reset at natural 15-minute intervals corresponding to 0, 15, 30 and 45 minutes after
+the hour. The daily limit resets at midnight UTC.
+Requests exceeding the limit will return `403 Forbidden` along with a JSON error message.
+Note that requests violating the short term limit will still count toward the long term limit.
+
+An application's limits and usage are reported on the [API application settings](https://www.strava.com/settings/api)
+page as well as returned with every API request as part of the HTTP Headers:
+
+<table class="parameters">
+  <tr>   
+    <td width="200px">
+        <span class="parameter-name">X-RateLimit-Limit</span>
+      <br>
+      <span class="parameter-description">
+        integer, integer <br /> two comma-separated values
+      </span>
+    </td>
+    <td>
+        15-minute limit, followed by daily limit.
+    </td>
+  </tr>
+  <tr>
+    <td width="200px">
+      <span class="parameter-name">X-RateLimit-Usage</span>
+      <br>
+      <span class="parameter-description">
+        integer, integer <br /> two comma-separated values
+      </span>
+    </td>
+    <td>
+        15-minute usage, followed by daily usage.
+    </td>
+  </tr>
+</table>
+<br>
+
+Below is an example request using to the Strava API using [HTTPie](https://httpie.org/), along with sample response headers for a
+successful and rate-limited request:
+
+###### Example request
+
+    $ http 'https://www.strava.com/api/v3/athlete' \
+        'Authorization:Bearer 83ebeabdec09f6670863766f792ead24d61fe3f9'
+
+###### Example successful response headers
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json; charset=utf-8
+    Date: Tue, 10 Oct 2013 20:11:01 GMT
+    X-Ratelimit-Limit: 600,30000
+    X-Ratelimit-Usage: 254,12536
+
+###### Example rate-limited response headers
+
+    HTTP/1.1 403 Forbidden
+    Content-Type: application/json; charset=utf-8
+    Date: Tue, 10 Oct 2013 20:11:05 GMT
+    X-Ratelimit-Limit: 600,30000
+    X-Ratelimit-Usage: 642,27300

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -101,6 +101,15 @@
           </div>
         </div>
       </div>
+      <div class="col-md-4">
+        <div class="card">
+          <div class="card-block">
+            <h3 class="card-title">Rate Limiting</h3>
+            <p class="card-text">Understand the rules for usage.</p>
+            <a href="/docs/rate-limiting" class="btn btn-primary">Review</a>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -36,6 +36,7 @@
                 <a class="dropdown-item" href="/docs">Home</a>
                 <a class="dropdown-item" href="/docs/reference">Reference</a>
                 <a class="dropdown-item" href="/docs/authentication">Authentication</a>
+                <a class="dropdown-item" href="/docs/rate-limiting">Rate Limiting</a>
               </div>
             </li>
             <li class="nav-item">


### PR DESCRIPTION
Background:
Rate limiting is an important aspect of most public APIs. [developers.strava.com](https://developers.strava.com) needs a page that explains our rate limiting policies.

Solution:
Add a page with the Strava API rate limiting information. Add a card-block on the home page, as well as a link to the new page in the header dropdown bar.

Result:
[developers.strava.com](https://developers.strava.com) has a page about rate limits.

Completes [CP-1772](https://strava.atlassian.net/browse/CP-1772)

**Rate limit page**
![screen shot 2017-11-20 at 3 58 57 pm](https://user-images.githubusercontent.com/13637569/33047662-bf723d14-ce0b-11e7-9340-079a39bc7492.png)

**Home page**
Before:
![screen shot 2017-11-20 at 3 54 18 pm](https://user-images.githubusercontent.com/13637569/33047528-1edd68a6-ce0b-11e7-9da8-0f772893a443.png)

After:
![screen shot 2017-11-20 at 3 48 38 pm](https://user-images.githubusercontent.com/13637569/33047534-26d86e84-ce0b-11e7-9946-ce7bdd1d054b.png)

**Dropdown bar**
Before:
![screen shot 2017-11-20 at 3 55 50 pm](https://user-images.githubusercontent.com/13637569/33047560-4f249016-ce0b-11e7-88fc-c91873db73cc.png)

After:
![screen shot 2017-11-20 at 3 41 36 pm](https://user-images.githubusercontent.com/13637569/33047563-5574b1a8-ce0b-11e7-87b6-89b7a8fa7d15.png)
