### PR TITLE
[CP-1790] Remove Client Libraries from homepage

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -32,15 +32,6 @@
       <div class="col-md-4">
         <div class="card">
           <div class="card-block">
-            <h3>Client Libraries </h3>
-            <p class="card-text">Libraries to get you started.</p>
-            <a href="" class="btn btn-secondary btn-disabled" disabled="disabled">Coming Soon</a>
-          </div>
-        </div>
-      </div>
-      <div class="col-md-4">
-        <div class="card">
-          <div class="card-block">
             <h3 class="card-title">Your App</h3>
             <p class="card-text">Register or edit the details of your app.</p>
             <a href="https://www.strava.com/settings/api" class="btn btn-primary">Create/Manage</a>


### PR DESCRIPTION
Input welcome for homepage styling and the box order.

Background:
There is a little box on [developers.strava.com](https://developers.strava.com) which says that Libraries are "Coming soon." Unfortunately this is not the case, since packaging these libraries appropriately and keeping track of various versions is not something the Strava API Team has the bandwith to do.

Solution:
Remove the Client Libraries box from the homepage.

Result:
People won't expect Client Libraries that we're not generating.

Completes [CP-1790](https://strava.atlassian.net/browse/CP-1790)

![screen shot 2017-11-28 at 4 36 38 pm](https://user-images.githubusercontent.com/13637569/33351959-5042609e-d45b-11e7-9a41-415f6f2ed2c0.png)
