### PR TITLE
[API-700] Clean up clubs endpoints

### DIFF
--- a/codegen/src/main/resources/strava-html/reference.mustache
+++ b/codegen/src/main/resources/strava-html/reference.mustache
@@ -122,7 +122,7 @@ type = "reference"
                           {{/responses}}
                           <tr>
                             <td>HTTP code 4xx, 5xx</td>
-                            <td>a <a href="#api-models-Fault">Fault</a> describing the reason for the error.</td>
+                            <td>A <a href="#api-models-Fault">Fault</a> describing the reason for the error.</td>
                           </tr>
                         </table>
                       </article>

--- a/swagger/swagger.json.mustache
+++ b/swagger/swagger.json.mustache
@@ -28,20 +28,22 @@
   },
   "security": [
     {
-      "strava_oauth": ["public"]
+      "strava_oauth": [
+        "public"
+      ]
     }
   ],
   "parameters": {
     "page": {
       "name": "page",
       "in": "query",
-      "description": "Page number",
+      "description": "Page number.",
       "type": "integer"
     },
     "perPage": {
       "name": "per_page",
       "in": "query",
-      "description": "Number of items per page",
+      "description": "Number of items per page. Defaults to 30.",
       "type": "integer",
       "default": 30
     }
@@ -125,7 +127,6 @@
             "schema": {
               "$ref": "{{reference_prefix}}/athlete.json#/DetailedAthlete"
             }
-
           }
         ],
         "responses": {
@@ -290,21 +291,51 @@
             "in": "query",
             "description": "Enables filtering of entries by a given gender",
             "type": "string",
-            "enum": ["M", "F"]
+            "enum": [
+              "M",
+              "F"
+            ]
           },
           {
             "name": "age_group",
             "in": "query",
             "description": "Enables filtering of entries by a given age-group",
             "type": "string",
-            "enum": ["0_19", "20_24", "25_34", "35_44", "45_54", "55_64", "65_69", "70_74", "75_plus"]
+            "enum": [
+              "0_19",
+              "20_24",
+              "25_34",
+              "35_44",
+              "45_54",
+              "55_64",
+              "65_69",
+              "70_74",
+              "75_plus"
+            ]
           },
           {
             "name": "weight_class",
             "in": "query",
             "description": "Enables filtering of entries by a given weight class",
             "type": "string",
-            "enum": ["0_124", "125_149", "150_164", "165_179", "180_199", "200_224", "225_249", "250_plus", "0_54", "55_64", "65_74", "75_84", "85_94", "95_104", "105_114", "115_plus"]
+            "enum": [
+              "0_124",
+              "125_149",
+              "150_164",
+              "165_179",
+              "180_199",
+              "200_224",
+              "225_249",
+              "250_plus",
+              "0_54",
+              "55_64",
+              "65_74",
+              "75_84",
+              "85_94",
+              "95_104",
+              "105_114",
+              "115_plus"
+            ]
           },
           {
             "name": "following",
@@ -324,7 +355,12 @@
             "in": "query",
             "description": "Enables filtering of entries by a given date range",
             "type": "string",
-            "enum": ["this_year", "this_month", "this_week", "today"]
+            "enum": [
+              "this_year",
+              "this_month",
+              "this_week",
+              "today"
+            ]
           },
           {
             "name": "context_entries",
@@ -424,7 +460,10 @@
             "in": "query",
             "description": "The activity of the segments",
             "type": "string",
-            "enum": ["running", "riding"]
+            "enum": [
+              "running",
+              "riding"
+            ]
           },
           {
             "name": "min_cat",
@@ -937,6 +976,34 @@
             "description": "The detailed representation of a club",
             "schema": {
               "$ref": "{{reference_prefix}}/club.json#/DetailedClub"
+            },
+            "examples": {
+              "application/json": {
+                "id": 1,
+                "resource_state": 3,
+                "name": "Team Strava Cycling",
+                "profile_medium": "https://dgalywyr863hv.cloudfront.net/pictures/clubs/1/1582/4/medium.jpg",
+                "profile": "https://dgalywyr863hv.cloudfront.net/pictures/clubs/1/1582/4/large.jpg",
+                "cover_photo": "https://dgalywyr863hv.cloudfront.net/pictures/clubs/1/4328276/1/large.jpg",
+                "cover_photo_small": "https://dgalywyr863hv.cloudfront.net/pictures/clubs/1/4328276/1/small.jpg",
+                "sport_type": "cycling",
+                "city": "San Francisco",
+                "state": "California",
+                "country": "United States",
+                "private": true,
+                "member_count": 116,
+                "featured": false,
+                "verified": false,
+                "url": "team-strava-bike",
+                "membership": "member",
+                "admin": false,
+                "owner": false,
+                "description": "Private club for Cyclists who work at Strava.",
+                "club_type": "company",
+                "post_count": 29,
+                "owner_id": 759,
+                "following_count": 107
+              }
             }
           },
           "default": {
@@ -979,6 +1046,31 @@
               "items": {
                 "$ref": "{{reference_prefix}}/athlete.json#/SummaryAthlete"
               }
+            },
+            "examples": {
+              "application/json": {
+                "id": 123456789,
+                "username": "psagan",
+                "resource_state": 2,
+                "firstname": "Peter",
+                "lastname": "Sagan",
+                "city": "Oakland",
+                "state": "California",
+                "country": "United States",
+                "sex": "M",
+                "premium": true,
+                "created_at": "2011-08-28T18:04:51Z",
+                "updated_at": "2018-02-01T17:03:18Z",
+                "badge_type_id": 4,
+                "profile_medium": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/123456789/123456789/3/medium.jpg",
+                "profile": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/123456789/123456789/3/large.jpg",
+                "friend": null,
+                "follower": null,
+                "email": "zack@strava.com",
+                "membership": "member",
+                "admin": false,
+                "owner": false
+              }
             }
           },
           "default": {
@@ -993,7 +1085,7 @@
     "/clubs/{id}/admins": {
       "get": {
         "operationId": "getClubAdminsById",
-        "summary": "List Club Administrators",
+        "summary": "List Club Administrators.",
         "description": "Returns a list of the administrators of a given club.",
         "parameters": [
           {
@@ -1021,48 +1113,29 @@
               "items": {
                 "$ref": "{{reference_prefix}}/athlete.json#/SummaryAthlete"
               }
-            }
-          },
-          "default": {
-            "description": "Unexpected error",
-            "schema": {
-              "$ref": "{{reference_prefix}}/fault.json#/Fault"
-            }
-          }
-        }
-      }
-    },
-    "/clubs/{id}/announcements": {
-      "get": {
-        "operationId": "getClubAnnouncementsById",
-        "summary": "List Club Announcements",
-        "description": "Returns a list of the announcements of a given club.",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "The identifier of the club.",
-            "required": true,
-            "type": "integer"
-          },
-          {
-            "$ref": "#/parameters/page"
-          },
-          {
-            "$ref": "#/parameters/perPage"
-          }
-        ],
-        "tags": [
-          "Clubs"
-        ],
-        "responses": {
-          "200": {
-            "description": "A list of announcements",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "{{reference_prefix}}/club.json#/ClubAnnouncement"
-              }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "id": 123456789,
+                  "username": "psagan",
+                  "resource_state": 2,
+                  "firstname": "Peter",
+                  "lastname": "Sagan",
+                  "city": "Oakland",
+                  "state": "California",
+                  "country": "United States",
+                  "sex": "F",
+                  "premium": false,
+                  "created_at": "2013-07-24T19:08:39Z",
+                  "updated_at": "2015-08-27T20:54:42Z",
+                  "badge_type_id": 0,
+                  "profile_medium": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/123456789/123456789/2/medium.jpg",
+                  "profile": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/123456789/294/123456789/large.jpg",
+                  "friend": null,
+                  "follower": null
+                }
+              ]
             }
           },
           "default": {
@@ -1078,7 +1151,7 @@
       "get": {
         "operationId": "getClubActivitiesById",
         "summary": "List Club Activities",
-        "description": "Returns a list of the activities of a given club.",
+        "description": "Retrieve recent activities from members of a specific club. The authenticated athlete must belong to the requested club in order to hit this endpoint. Pagination is supported. Enhanced Privacy Mode is respected for all activities.",
         "parameters": [
           {
             "name": "id",
@@ -1105,6 +1178,94 @@
               "items": {
                 "$ref": "{{reference_prefix}}/activity.json#/SummaryActivity"
               }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "id": 123456789,
+                  "resource_state": 2,
+                  "external_id": "garmin_push_123456789",
+                  "upload_id": 987654321,
+                  "athlete": {
+                    "id": 123456789,
+                    "username": "psagan",
+                    "resource_state": 2,
+                    "firstname": "Peter",
+                    "lastname": "Sagan",
+                    "city": "Oakland",
+                    "state": "CA",
+                    "country": "United States",
+                    "sex": "M",
+                    "premium": true,
+                    "created_at": "2011-02-26T06:07:54Z",
+                    "updated_at": "2018-02-02T00:46:25Z",
+                    "badge_type_id": 1,
+                    "profile_medium": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/123456789/123456789/1/medium.jpg",
+                    "profile": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/123456789/123456789/1/large.jpg",
+                    "friend": null,
+                    "follower": null
+                  },
+                  "name": "Tour of California Stage 2",
+                  "distance": 48576.3,
+                  "moving_time": 5440,
+                  "elapsed_time": 5621,
+                  "total_elevation_gain": 256,
+                  "type": "Ride",
+                  "start_date": "2018-02-09T19:25:04Z",
+                  "start_date_local": "2018-02-09T11:25:04Z",
+                  "timezone": "(GMT-08:00) America/Los_Angeles",
+                  "utc_offset": -28800,
+                  "start_latlng": [
+                    37.69,
+                    -121.71
+                  ],
+                  "end_latlng": [
+                    37.69,
+                    -121.71
+                  ],
+                  "location_city": "Oakland",
+                  "location_state": "CA",
+                  "location_country": "United States",
+                  "start_latitude": 37.69,
+                  "start_longitude": -121.71,
+                  "achievement_count": 0,
+                  "kudos_count": 3,
+                  "comment_count": 0,
+                  "athlete_count": 10,
+                  "photo_count": 0,
+                  "map": {
+                    "id": "a1399596448",
+                    "summary_polyline": "{_`eFl}yeVd@iBpFk@pBgCrDB@uQ{BeFnD{JvH}DuG}D_KrBPaIlj@Yqj@@StFAuEiBo@olAf@gLmAkLbCmMm@{PpJoP_CmRhCyGvCcLrKbElW~O~]yg@~@c@tHjCt^mHnKv@|Zg[~@]hw@gUbBQbrA}k@b@\\jlCgzAd@WjrAqOxPeHrPeErSgLsBqJvAsNfJiZh]}EpOwHfIyA`NAfi@_ExR?bJaEjFe@`I{CrKSfLoC|KN~R`DzAlHc@tOwP|M_@nOaNhJyPrCeMzJwD~E_Fc@}AuGmA}NoXuDcC_GMPeOpOaVvOyDxM}QGy]hEyb@bNk^bNqNXmqAnrDCFapBcl@sAb@onBbSMpBqDb{@Np@qr@fe@FxTwEfr@}]hwBt@JiqAcLT_CeYwEyM{I|BaErKxBtFApQkDWeB`CeGn@M~A",
+                    "resource_state": 2
+                  },
+                  "trainer": false,
+                  "commute": false,
+                  "manual": false,
+                  "private": false,
+                  "flagged": false,
+                  "gear_id": "b3853379",
+                  "from_accepted_tag": false,
+                  "average_speed": 8.929,
+                  "max_speed": 15.9,
+                  "average_cadence": 86.1,
+                  "average_temp": 24,
+                  "average_watts": 148,
+                  "weighted_average_watts": 188,
+                  "kilojoules": 805,
+                  "device_watts": true,
+                  "has_heartrate": true,
+                  "average_heartrate": 131.4,
+                  "max_heartrate": 167,
+                  "max_watts": 814,
+                  "elev_high": 276.6,
+                  "elev_low": 168,
+                  "pr_count": 0,
+                  "total_photo_count": 0,
+                  "has_kudoed": false,
+                  "workout_type": 10,
+                  "suffer_score": 54
+                }
+              ]
             }
           },
           "default": {
@@ -1138,6 +1299,13 @@
             "description": "A representation of the athlete's membership in the club",
             "schema": {
               "$ref": "{{reference_prefix}}/club.json#/MembershipApplication"
+            },
+            "examples": {
+              "application/json": {
+                "success": true,
+                "active": true,
+                "membership": "member"
+              }
             }
           },
           "default": {
@@ -1171,6 +1339,12 @@
             "description": "A representation of the athlete's membership in the club",
             "schema": {
               "$ref": "{{reference_prefix}}/club.json#/MembershipApplication"
+            },
+            "examples": {
+              "application/json": {
+                "success": true,
+                "active": false
+              }
             }
           },
           "default": {
@@ -1206,6 +1380,28 @@
               "items": {
                 "$ref": "{{reference_prefix}}/club.json#/SummaryClub"
               }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "id": 231407,
+                  "resource_state": 2,
+                  "name": "The Strava Club",
+                  "profile_medium": "https://dgalywyr863hv.cloudfront.net/pictures/clubs/231407/5319085/1/medium.jpg",
+                  "profile": "https://dgalywyr863hv.cloudfront.net/pictures/clubs/231407/5319085/1/large.jpg",
+                  "cover_photo": "https://dgalywyr863hv.cloudfront.net/pictures/clubs/231407/5098428/4/large.jpg",
+                  "cover_photo_small": "https://dgalywyr863hv.cloudfront.net/pictures/clubs/231407/5098428/4/small.jpg",
+                  "sport_type": "other",
+                  "city": "San Francisco",
+                  "state": "California",
+                  "country": "United States",
+                  "private": false,
+                  "member_count": 93151,
+                  "featured": false,
+                  "verified": true,
+                  "url": "strava"
+                }
+              ]
             }
           },
           "default": {
@@ -1330,7 +1526,9 @@
         "operationId": "createUpload",
         "summary": "Upload Activity",
         "description": "Uploads a new data file to create an activity from.",
-        "consumes": ["multipart/form-data"],
+        "consumes": [
+          "multipart/form-data"
+        ],
         "parameters": [
           {
             "name": "file",
@@ -1373,7 +1571,14 @@
             "in": "formData",
             "description": "The format of the uploaded file.",
             "type": "string",
-            "enum": ["fit", "fit.gz", "tcx", "tcx.gz", "gpx", "gpx.gz"]
+            "enum": [
+              "fit",
+              "fit.gz",
+              "tcx",
+              "tcx.gz",
+              "gpx",
+              "gpx.gz"
+            ]
           },
           {
             "name": "external_id",


### PR DESCRIPTION
I added sanitized responses for all clubs endpoints, removed the deprecated `clubs/id/announcements` endpoint from the swagger spec altogether, and fixed little english nits along the way. I also noticed a bug in the model that's being returned in the `clubs/id/leave` endpoint, which I documented in [API-708](https://strava.atlassian.net/browse/API-708).

There's a lot of content here but no new design elements, so I don't think a screenshot would be very useful. I think english errors and keeping the data safe / anonymous is what's most important.

cc @mindy-stivers 

Completes [API-700](https://strava.atlassian.net/browse/API-700)