### PR TITLE
[API-711] Typo in getLeaderboardBySegmentId

### DIFF
--- a/swagger/swagger.json.mustache
+++ b/swagger/swagger.json.mustache
@@ -281,7 +281,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The identifier of the segment to get leaderbaords for.",
+            "description": "The identifier of the segment to get the leaderboards for.",
             "required": true,
             "type": "integer",
             "format": "int64"


### PR DESCRIPTION
Fixing the typo in the Segment Leaderboard API.