### PR TITLE
[API-698] Clean up activities endpoints and documentation

### DIFF
--- a/swagger/swagger.json.mustache
+++ b/swagger/swagger.json.mustache
@@ -256,6 +256,72 @@
             "description": "Heart rate and power zones.",
             "schema": {
               "$ref": "{{reference_prefix}}/zones.json#/Zones"
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "distribution_buckets": [
+                    {
+                      "max": 0,
+                      "min": 0,
+                      "time": 1498
+                    },
+                    {
+                      "max": 50,
+                      "min": 0,
+                      "time": 62
+                    },
+                    {
+                      "max": 100,
+                      "min": 50,
+                      "time": 169
+                    },
+                    {
+                      "max": 150,
+                      "min": 100,
+                      "time": 536
+                    },
+                    {
+                      "max": 200,
+                      "min": 150,
+                      "time": 672
+                    },
+                    {
+                      "max": 250,
+                      "min": 200,
+                      "time": 821
+                    },
+                    {
+                      "max": 300,
+                      "min": 250,
+                      "time": 529
+                    },
+                    {
+                      "max": 350,
+                      "min": 300,
+                      "time": 251
+                    },
+                    {
+                      "max": 400,
+                      "min": 350,
+                      "time": 80
+                    },
+                    {
+                      "max": 450,
+                      "min": 400,
+                      "time": 81
+                    },
+                    {
+                      "max": -1,
+                      "min": 450,
+                      "time": 343
+                    }
+                  ],
+                  "type": "power",
+                  "resource_state": 3,
+                  "sensor_based": true
+                }
+              ]
             }
           },
           "default": {
@@ -824,7 +890,7 @@
       "get": {
         "operationId": "getActivityById",
         "summary": "Get Activity",
-        "description": "Returns an activity that is owned by the authenticated athlete.",
+        "description": "Returns the given activity that is owned by the authenticated athlete.",
         "parameters": [
           {
             "name": "id",
@@ -837,7 +903,7 @@
           {
             "name": "include_all_efforts",
             "in": "query",
-            "description": "Whether all segments efforts should be included in the response.",
+            "description": "To include all segments efforts.",
             "type": "boolean"
           }
         ],
@@ -849,6 +915,211 @@
             "description": "The activity's detailed representation.",
             "schema": {
               "$ref": "{{reference_prefix}}/activity.json#/DetailedActivity"
+            },
+            "examples": {
+              "application/json": {
+                "id": 12345678987654321,
+                "resource_state": 3,
+                "external_id": "garmin_push_12345678987654321",
+                "upload_id": 98765432123456789,
+                "athlete": {
+                  "id": 134815,
+                  "resource_state": 1
+                },
+                "name": "Happy Friday",
+                "distance": 28099,
+                "moving_time": 4207,
+                "elapsed_time": 4410,
+                "total_elevation_gain": 516,
+                "type": "Ride",
+                "start_date": "2018-02-16T14:52:54Z",
+                "start_date_local": "2018-02-16T06:52:54Z",
+                "timezone": "(GMT-08:00) America/Los_Angeles",
+                "utc_offset": -28800,
+                "start_latlng": [
+                  37.83,
+                  -122.26
+                ],
+                "end_latlng": [
+                  37.83,
+                  -122.26
+                ],
+                "location_city": null,
+                "location_state": null,
+                "location_country": "United States",
+                "start_latitude": 37.83,
+                "start_longitude": -122.26,
+                "achievement_count": 0,
+                "kudos_count": 19,
+                "comment_count": 0,
+                "athlete_count": 1,
+                "photo_count": 0,
+                "map": {
+                  "id": "a1410355832",
+                  "polyline": "ki{eFvqfiVqAWQIGEEKAYJgBVqDJ{BHa@jAkNJw@Pw@V{APs@^aABQAOEQGKoJ_FuJkFqAo@{A}@sH{DiAs@Q]?WVy@`@oBt@_CB]KYMMkB{AQEI@WT{BlE{@zAQPI@ICsCqA_BcAeCmAaFmCqIoEcLeG}KcG}A}@cDaBiDsByAkAuBqBi@y@_@o@o@kB}BgIoA_EUkAMcACa@BeBBq@LaAJe@b@uA`@_AdBcD`@iAPq@RgALqAB{@EqAyAoOCy@AmCBmANqBLqAZkB\\iCPiBJwCCsASiCq@iD]eA]y@[i@w@mAa@i@k@g@kAw@i@Ya@Q]EWFMLa@~BYpAFNpA`Aj@n@X`@V`AHh@JfB@xAMvAGZGHIDIAWOEQNcC@sACYK[MSOMe@QKKKYOs@UYQISCQ?Q@WNo@r@OHGAGCKOQ_BU}@MQGG]Io@@c@FYNg@d@s@d@ODQAMOMaASs@_@a@SESAQDqBn@a@RO?KK?UBU\\kA@Y?WMo@Iy@GWQ_@WSSGg@AkABQB_Ap@_A^o@b@Q@o@IS@OHi@n@OFS?OI}@iAQMQGQC}@DOIIUK{@IUOMyBo@kASOKIQCa@L[|AgATWN[He@?QKw@FOPCh@Fx@l@TDLELKl@aAHIJEX@r@ZTDV@LENQVg@RkA@c@MeA?WFOPMf@Ej@Fj@@LGHKDM?_@_@iC?a@HKRIl@NT?FCHMFW?YEYGWQa@GYBiAIq@Gq@L_BHSHK|@WJETSLQZs@z@_A~@uA^U`@G\\CRB\\Tl@p@Th@JZ^bB`@lAHLXVLDP?LGFSKiDBo@d@wBVi@R]VYVE\\@`@Lh@Fh@CzAk@RSDQA]GYe@eAGWSiBAWBWBIJORK`@KPOPSTg@h@}Ad@o@F[E_@EGMKUGmAEYGMIMYKs@?a@J}@@_BD_@HQJMx@e@LKHKHWAo@UoAAWFmAH}@?w@C[YwAAc@HSNM|Ao@rA}@zAq@`@a@j@eAxAuBXQj@MXSR[b@gAFg@?YISOGaAHi@Xw@v@_@d@WRSFqARUHQJc@d@m@`A[VSFUBcAEU@WFULUPa@v@Y~@UrBc@dBI~@?l@P~ABt@N`HEjA]zAEp@@p@TrBCl@CTQb@k@dAg@jAU^KJYLK@k@A[Js@d@a@b@]RgBl@[FMAw@[]G]?m@D_@F]P[Vu@t@[TMF_@Do@E_@@q@P]PWZUZw@vAkAlAGJOj@IlAMd@OR{@p@a@d@sBpD]v@a@`Aa@n@]TODgBVk@Pe@^cBfBc@Rs@La@RSPm@|@wCpDS^Wp@QZML{@l@qBbCYd@k@lAIVCZBZNTr@`@RRHZANIZQPKDW@e@CaASU?I@YTKRQx@@\\VmALYRQLCL?v@P|@D\\GJEFKDM@OCa@COOYIGm@YMUCM@]JYr@uAx@kAt@}@jAeAPWbAkBj@s@bAiAz@oAj@m@VQlAc@VQ~@aA`Au@p@Q`AIv@MZORUV_@p@iB|AoCh@q@dAaANUNWH[N{AJ[^m@t@_Av@wA\\a@`@W`@In@Al@B^E`@Wl@u@\\[VQ\\K`@Eb@?R@dAZP@d@CRExAs@\\Yt@{@LG\\MjAATINOXo@d@kAl@_AHYBOCe@QiBCm@Fq@\\wADo@AyGEeBWuB@YHu@Tu@Lk@VcCTo@d@aA\\WJE`@G~@FP?VI\\U~@sANO`@SfAMj@U\\WjAsAXS`@UNENALBHFFL?^Ml@Uj@]b@q@RUJSPkChEc@XcAb@sA|@]PaA\\OJKNER?TDTNj@Jn@?p@OfC@ZR`B@VCV_@n@{@l@WbACv@OlABnAPl@LNNHbBBNBLFFJ@^GLg@x@i@|AMP[X}@XOJKPET?l@LhAFXp@fBDRCd@S\\_@Ps@PQ@}A]S?QDe@V]b@MR[fAKt@ErAF~CANILYDKGIKe@{@Yy@e@sB[gA[c@e@YUCU?WBUHUNQPq@`AiArAMV[^e@Zc@JQJKNMz@?r@Bb@PfAAfA@VVbADn@E`@KHSEe@SMAKDKFM\\^dDCh@m@LoAQ_@@MFOZLfBEl@QbASd@KLQBOAaAc@QAQ@QHc@v@ONMJOBOCg@c@]O[EMBKFGL?RHv@ARERGNe@h@{@h@WVGNDt@JLNFPFz@LdBf@f@PJNHPF`ADPJJJDl@I`@B^Tp@bALJNDNALIf@i@PGPCt@DNE`@Uv@[dAw@RITGRCtAARBPJLPJRZxB?VEX_@vAAR?RDNHJJBh@UnBm@h@IRDRJNNJPNbBFRJLLBLCzAmAd@Uf@Gf@?P@PFJNHPFTH`BDTHNJJJ@LG`@m@^YPER@RDPHNNJRLn@HRLN^VNPHTFX@\\UlDFb@FHh@NP@HKPsB?}ASkCQ{@[y@q@}@cA{@KOCQDa@t@{CFGJCf@Nl@ZtA~@r@p@`@h@rAxBd@rA\\fARdAPjANrB?f@AtBCd@QfBkAjJOlBChA?rBFrBNlBdAfKFzAC~@Iz@Mz@Sv@s@jBmAxBi@hAWt@Sv@Qx@O`BA`@?dAPfBVpAd@`BfBlFf@fBdA~Cr@pAz@fApBhBjAt@H?IL?FBFJLx@^lHvDvh@~XnElCbAd@pGhDbAb@nAr@`Ad@`GhDnBbAxCbBrWhNJJDPARGP_@t@Qh@]pAUtAoA`Ny@jJApBBNFLJFJBv@Hb@HBF?\\",
+                  "resource_state": 3,
+                  "summary_polyline": "ki{eFvqfiVsBmA`Feh@qg@iX`B}JeCcCqGjIq~@kf@cM{KeHeX`@_GdGkSeBiXtB}YuEkPwFyDeAzAe@pC~DfGc@bIOsGmCcEiD~@oBuEkFhBcBmDiEfAVuDiAuD}NnDaNiIlCyDD_CtJKv@wGhD]YyEzBo@g@uKxGmHpCGtEtI~AuLrHkAcAaIvEgH_EaDR_FpBuBg@sNxHqEtHgLoTpIiCzKNr[sB|Es\\`JyObYeMbGsMnPsAfDxAnD}DBu@bCx@{BbEEyAoD`AmChNoQzMoGhOwX|[yIzBeFKg[zAkIdU_LiHxK}HzEh@vM_BtBg@xGzDbCcF~GhArHaIfByAhLsDiJuC?_HbHd@nL_Cz@ZnEkDDy@hHwJLiCbIrNrIvN_EfAjDWlEnEiAfBxDlFkBfBtEfDaAzBvDKdFx@|@XgJmDsHhAgD`GfElEzOwBnYdBxXgGlSc@bGdHpW|HdJztBnhAgFxc@HnCvBdA"
+                },
+                "trainer": false,
+                "commute": false,
+                "manual": false,
+                "private": false,
+                "flagged": false,
+                "gear_id": "b12345678987654321",
+                "from_accepted_tag": false,
+                "average_speed": 6.679,
+                "max_speed": 18.5,
+                "average_cadence": 78.5,
+                "average_temp": 4,
+                "average_watts": 185.5,
+                "weighted_average_watts": 230,
+                "kilojoules": 780.5,
+                "device_watts": true,
+                "has_heartrate": false,
+                "max_watts": 743,
+                "elev_high": 446.6,
+                "elev_low": 17.2,
+                "pr_count": 0,
+                "total_photo_count": 2,
+                "has_kudoed": false,
+                "workout_type": 10,
+                "suffer_score": null,
+                "description": "",
+                "calories": 870.2,
+                "segment_efforts": [
+                  {
+                    "id": 12345678987654321,
+                    "resource_state": 2,
+                    "name": "Tunnel Rd.",
+                    "activity": {
+                      "id": 12345678987654321,
+                      "resource_state": 1
+                    },
+                    "athlete": {
+                      "id": 134815,
+                      "resource_state": 1
+                    },
+                    "elapsed_time": 2038,
+                    "moving_time": 2038,
+                    "start_date": "2018-02-16T14:56:25Z",
+                    "start_date_local": "2018-02-16T06:56:25Z",
+                    "distance": 9434.8,
+                    "start_index": 211,
+                    "end_index": 2246,
+                    "average_cadence": 78.6,
+                    "device_watts": true,
+                    "average_watts": 237.6,
+                    "segment": {
+                      "id": 673683,
+                      "resource_state": 2,
+                      "name": "Tunnel Rd.",
+                      "activity_type": "Ride",
+                      "distance": 9220.7,
+                      "average_grade": 4.2,
+                      "maximum_grade": 25.8,
+                      "elevation_high": 426.5,
+                      "elevation_low": 43.4,
+                      "start_latlng": [
+                        37.8346153,
+                        -122.2520872
+                      ],
+                      "end_latlng": [
+                        37.8476261,
+                        -122.2008944
+                      ],
+                      "start_latitude": 37.8346153,
+                      "start_longitude": -122.2520872,
+                      "end_latitude": 37.8476261,
+                      "end_longitude": -122.2008944,
+                      "climb_category": 3,
+                      "city": "Oakland",
+                      "state": "CA",
+                      "country": "United States",
+                      "private": false,
+                      "hazardous": false,
+                      "starred": false
+                    },
+                    "kom_rank": null,
+                    "pr_rank": null,
+                    "achievements": [],
+                    "hidden": false
+                  }
+                ],
+                "splits_metric": [
+                  {
+                    "distance": 1001.5,
+                    "elapsed_time": 141,
+                    "elevation_difference": 4.4,
+                    "moving_time": 141,
+                    "split": 1,
+                    "average_speed": 7.1,
+                    "pace_zone": 0
+                  }
+                ],
+                "laps": [
+                  {
+                    "id": 4479306946,
+                    "resource_state": 2,
+                    "name": "Lap 1",
+                    "activity": {
+                      "id": 1410355832,
+                      "resource_state": 1
+                    },
+                    "athlete": {
+                      "id": 134815,
+                      "resource_state": 1
+                    },
+                    "elapsed_time": 1573,
+                    "moving_time": 1569,
+                    "start_date": "2018-02-16T14:52:54Z",
+                    "start_date_local": "2018-02-16T06:52:54Z",
+                    "distance": 8046.72,
+                    "start_index": 0,
+                    "end_index": 1570,
+                    "total_elevation_gain": 276,
+                    "average_speed": 5.12,
+                    "max_speed": 9.5,
+                    "average_cadence": 78.6,
+                    "device_watts": true,
+                    "average_watts": 233.1,
+                    "lap_index": 1,
+                    "split": 1
+                  }
+                ],
+                "gear": {
+                  "id": "b12345678987654321",
+                  "primary": true,
+                  "name": "Tarmac",
+                  "resource_state": 2,
+                  "distance": 32547610
+                },
+                "partner_brand_tag": null,
+                "photos": {
+                  "primary": {
+                    "id": null,
+                    "unique_id": "3FDGKL3-204E-4867-9E8D-89FC79EAAE17",
+                    "urls": {
+                      "100": "https://dgtzuqphqg23d.cloudfront.net/Bv93zv5t_mr57v0wXFbY_JyvtucgmU5Ym6N9z_bKeUI-128x96.jpg",
+                      "600": "https://dgtzuqphqg23d.cloudfront.net/Bv93zv5t_mr57v0wXFbY_JyvtucgmU5Ym6N9z_bKeUI-768x576.jpg"
+                    },
+                    "source": 1
+                  },
+                  "use_primary_photo": true,
+                  "count": 2
+                },
+                "highlighted_kudosers": [
+                  {
+                    "destination_url": "strava://athletes/12345678987654321",
+                    "display_name": "Marianne V.",
+                    "avatar_url": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/12345678987654321/12345678987654321/3/medium.jpg",
+                    "show_name": true
+                  }
+                ],
+                "device_name": "Garmin Edge 1030",
+                "embed_token": "18e4615989b47dd4ff3dc711b0aa4502e4b311a9",
+                "segment_leaderboard_opt_out": false,
+                "leaderboard_opt_out": false
+              }
             }
           },
           "default": {
@@ -862,7 +1133,7 @@
       "put": {
         "operationId": "updateActivityById",
         "summary": "Update Activity",
-        "description": "Updates an activity for a given identifier.",
+        "description": "Updates the given activity that is owned by the authenticated athlete.",
         "parameters": [
           {
             "name": "id",
@@ -888,6 +1159,211 @@
             "description": "The activity's detailed representation.",
             "schema": {
               "$ref": "{{reference_prefix}}/activity.json#/DetailedActivity"
+            },
+            "examples": {
+              "application/json": {
+                "id": 12345678987654321,
+                "resource_state": 3,
+                "external_id": "garmin_push_12345678987654321",
+                "upload_id": 98765432123456789,
+                "athlete": {
+                  "id": 134815,
+                  "resource_state": 1
+                },
+                "name": "Happy Friday",
+                "distance": 28099,
+                "moving_time": 4207,
+                "elapsed_time": 4410,
+                "total_elevation_gain": 516,
+                "type": "Ride",
+                "start_date": "2018-02-16T14:52:54Z",
+                "start_date_local": "2018-02-16T06:52:54Z",
+                "timezone": "(GMT-08:00) America/Los_Angeles",
+                "utc_offset": -28800,
+                "start_latlng": [
+                  37.83,
+                  -122.26
+                ],
+                "end_latlng": [
+                  37.83,
+                  -122.26
+                ],
+                "location_city": null,
+                "location_state": null,
+                "location_country": "United States",
+                "start_latitude": 37.83,
+                "start_longitude": -122.26,
+                "achievement_count": 0,
+                "kudos_count": 19,
+                "comment_count": 0,
+                "athlete_count": 1,
+                "photo_count": 0,
+                "map": {
+                  "id": "a1410355832",
+                  "polyline": "ki{eFvqfiVqAWQIGEEKAYJgBVqDJ{BHa@jAkNJw@Pw@V{APs@^aABQAOEQGKoJ_FuJkFqAo@{A}@sH{DiAs@Q]?WVy@`@oBt@_CB]KYMMkB{AQEI@WT{BlE{@zAQPI@ICsCqA_BcAeCmAaFmCqIoEcLeG}KcG}A}@cDaBiDsByAkAuBqBi@y@_@o@o@kB}BgIoA_EUkAMcACa@BeBBq@LaAJe@b@uA`@_AdBcD`@iAPq@RgALqAB{@EqAyAoOCy@AmCBmANqBLqAZkB\\iCPiBJwCCsASiCq@iD]eA]y@[i@w@mAa@i@k@g@kAw@i@Ya@Q]EWFMLa@~BYpAFNpA`Aj@n@X`@V`AHh@JfB@xAMvAGZGHIDIAWOEQNcC@sACYK[MSOMe@QKKKYOs@UYQISCQ?Q@WNo@r@OHGAGCKOQ_BU}@MQGG]Io@@c@FYNg@d@s@d@ODQAMOMaASs@_@a@SESAQDqBn@a@RO?KK?UBU\\kA@Y?WMo@Iy@GWQ_@WSSGg@AkABQB_Ap@_A^o@b@Q@o@IS@OHi@n@OFS?OI}@iAQMQGQC}@DOIIUK{@IUOMyBo@kASOKIQCa@L[|AgATWN[He@?QKw@FOPCh@Fx@l@TDLELKl@aAHIJEX@r@ZTDV@LENQVg@RkA@c@MeA?WFOPMf@Ej@Fj@@LGHKDM?_@_@iC?a@HKRIl@NT?FCHMFW?YEYGWQa@GYBiAIq@Gq@L_BHSHK|@WJETSLQZs@z@_A~@uA^U`@G\\CRB\\Tl@p@Th@JZ^bB`@lAHLXVLDP?LGFSKiDBo@d@wBVi@R]VYVE\\@`@Lh@Fh@CzAk@RSDQA]GYe@eAGWSiBAWBWBIJORK`@KPOPSTg@h@}Ad@o@F[E_@EGMKUGmAEYGMIMYKs@?a@J}@@_BD_@HQJMx@e@LKHKHWAo@UoAAWFmAH}@?w@C[YwAAc@HSNM|Ao@rA}@zAq@`@a@j@eAxAuBXQj@MXSR[b@gAFg@?YISOGaAHi@Xw@v@_@d@WRSFqARUHQJc@d@m@`A[VSFUBcAEU@WFULUPa@v@Y~@UrBc@dBI~@?l@P~ABt@N`HEjA]zAEp@@p@TrBCl@CTQb@k@dAg@jAU^KJYLK@k@A[Js@d@a@b@]RgBl@[FMAw@[]G]?m@D_@F]P[Vu@t@[TMF_@Do@E_@@q@P]PWZUZw@vAkAlAGJOj@IlAMd@OR{@p@a@d@sBpD]v@a@`Aa@n@]TODgBVk@Pe@^cBfBc@Rs@La@RSPm@|@wCpDS^Wp@QZML{@l@qBbCYd@k@lAIVCZBZNTr@`@RRHZANIZQPKDW@e@CaASU?I@YTKRQx@@\\VmALYRQLCL?v@P|@D\\GJEFKDM@OCa@COOYIGm@YMUCM@]JYr@uAx@kAt@}@jAeAPWbAkBj@s@bAiAz@oAj@m@VQlAc@VQ~@aA`Au@p@Q`AIv@MZORUV_@p@iB|AoCh@q@dAaANUNWH[N{AJ[^m@t@_Av@wA\\a@`@W`@In@Al@B^E`@Wl@u@\\[VQ\\K`@Eb@?R@dAZP@d@CRExAs@\\Yt@{@LG\\MjAATINOXo@d@kAl@_AHYBOCe@QiBCm@Fq@\\wADo@AyGEeBWuB@YHu@Tu@Lk@VcCTo@d@aA\\WJE`@G~@FP?VI\\U~@sANO`@SfAMj@U\\WjAsAXS`@UNENALBHFFL?^Ml@Uj@]b@q@RUJSPkChEc@XcAb@sA|@]PaA\\OJKNER?TDTNj@Jn@?p@OfC@ZR`B@VCV_@n@{@l@WbACv@OlABnAPl@LNNHbBBNBLFFJ@^GLg@x@i@|AMP[X}@XOJKPET?l@LhAFXp@fBDRCd@S\\_@Ps@PQ@}A]S?QDe@V]b@MR[fAKt@ErAF~CANILYDKGIKe@{@Yy@e@sB[gA[c@e@YUCU?WBUHUNQPq@`AiArAMV[^e@Zc@JQJKNMz@?r@Bb@PfAAfA@VVbADn@E`@KHSEe@SMAKDKFM\\^dDCh@m@LoAQ_@@MFOZLfBEl@QbASd@KLQBOAaAc@QAQ@QHc@v@ONMJOBOCg@c@]O[EMBKFGL?RHv@ARERGNe@h@{@h@WVGNDt@JLNFPFz@LdBf@f@PJNHPF`ADPJJJDl@I`@B^Tp@bALJNDNALIf@i@PGPCt@DNE`@Uv@[dAw@RITGRCtAARBPJLPJRZxB?VEX_@vAAR?RDNHJJBh@UnBm@h@IRDRJNNJPNbBFRJLLBLCzAmAd@Uf@Gf@?P@PFJNHPFTH`BDTHNJJJ@LG`@m@^YPER@RDPHNNJRLn@HRLN^VNPHTFX@\\UlDFb@FHh@NP@HKPsB?}ASkCQ{@[y@q@}@cA{@KOCQDa@t@{CFGJCf@Nl@ZtA~@r@p@`@h@rAxBd@rA\\fARdAPjANrB?f@AtBCd@QfBkAjJOlBChA?rBFrBNlBdAfKFzAC~@Iz@Mz@Sv@s@jBmAxBi@hAWt@Sv@Qx@O`BA`@?dAPfBVpAd@`BfBlFf@fBdA~Cr@pAz@fApBhBjAt@H?IL?FBFJLx@^lHvDvh@~XnElCbAd@pGhDbAb@nAr@`Ad@`GhDnBbAxCbBrWhNJJDPARGP_@t@Qh@]pAUtAoA`Ny@jJApBBNFLJFJBv@Hb@HBF?\\",
+                  "resource_state": 3,
+                  "summary_polyline": "ki{eFvqfiVsBmA`Feh@qg@iX`B}JeCcCqGjIq~@kf@cM{KeHeX`@_GdGkSeBiXtB}YuEkPwFyDeAzAe@pC~DfGc@bIOsGmCcEiD~@oBuEkFhBcBmDiEfAVuDiAuD}NnDaNiIlCyDD_CtJKv@wGhD]YyEzBo@g@uKxGmHpCGtEtI~AuLrHkAcAaIvEgH_EaDR_FpBuBg@sNxHqEtHgLoTpIiCzKNr[sB|Es\\`JyObYeMbGsMnPsAfDxAnD}DBu@bCx@{BbEEyAoD`AmChNoQzMoGhOwX|[yIzBeFKg[zAkIdU_LiHxK}HzEh@vM_BtBg@xGzDbCcF~GhArHaIfByAhLsDiJuC?_HbHd@nL_Cz@ZnEkDDy@hHwJLiCbIrNrIvN_EfAjDWlEnEiAfBxDlFkBfBtEfDaAzBvDKdFx@|@XgJmDsHhAgD`GfElEzOwBnYdBxXgGlSc@bGdHpW|HdJztBnhAgFxc@HnCvBdA"
+                },
+                "trainer": false,
+                "commute": false,
+                "manual": false,
+                "private": false,
+                "flagged": false,
+                "gear_id": "b12345678987654321",
+                "from_accepted_tag": false,
+                "average_speed": 6.679,
+                "max_speed": 18.5,
+                "average_cadence": 78.5,
+                "average_temp": 4,
+                "average_watts": 185.5,
+                "weighted_average_watts": 230,
+                "kilojoules": 780.5,
+                "device_watts": true,
+                "has_heartrate": false,
+                "max_watts": 743,
+                "elev_high": 446.6,
+                "elev_low": 17.2,
+                "pr_count": 0,
+                "total_photo_count": 2,
+                "has_kudoed": false,
+                "workout_type": 10,
+                "suffer_score": null,
+                "description": "",
+                "calories": 870.2,
+                "segment_efforts": [
+                  {
+                    "id": 12345678987654321,
+                    "resource_state": 2,
+                    "name": "Tunnel Rd.",
+                    "activity": {
+                      "id": 12345678987654321,
+                      "resource_state": 1
+                    },
+                    "athlete": {
+                      "id": 12345678987654321,
+                      "resource_state": 1
+                    },
+                    "elapsed_time": 2038,
+                    "moving_time": 2038,
+                    "start_date": "2018-02-16T14:56:25Z",
+                    "start_date_local": "2018-02-16T06:56:25Z",
+                    "distance": 9434.8,
+                    "start_index": 211,
+                    "end_index": 2246,
+                    "average_cadence": 78.6,
+                    "device_watts": true,
+                    "average_watts": 237.6,
+                    "segment": {
+                      "id": 673683,
+                      "resource_state": 2,
+                      "name": "Tunnel Rd.",
+                      "activity_type": "Ride",
+                      "distance": 9220.7,
+                      "average_grade": 4.2,
+                      "maximum_grade": 25.8,
+                      "elevation_high": 426.5,
+                      "elevation_low": 43.4,
+                      "start_latlng": [
+                        37.8346153,
+                        -122.2520872
+                      ],
+                      "end_latlng": [
+                        37.8476261,
+                        -122.2008944
+                      ],
+                      "start_latitude": 37.8346153,
+                      "start_longitude": -122.2520872,
+                      "end_latitude": 37.8476261,
+                      "end_longitude": -122.2008944,
+                      "climb_category": 3,
+                      "city": "Oakland",
+                      "state": "CA",
+                      "country": "United States",
+                      "private": false,
+                      "hazardous": false,
+                      "starred": false
+                    },
+                    "kom_rank": null,
+                    "pr_rank": null,
+                    "achievements": [],
+                    "hidden": false
+                  }
+                ],
+                "splits_metric": [
+                  {
+                    "distance": 1001.5,
+                    "elapsed_time": 141,
+                    "elevation_difference": 4.4,
+                    "moving_time": 141,
+                    "split": 1,
+                    "average_speed": 7.1,
+                    "pace_zone": 0
+                  }
+                ],
+                "laps": [
+                  {
+                    "id": 4479306946,
+                    "resource_state": 2,
+                    "name": "Lap 1",
+                    "activity": {
+                      "id": 1410355832,
+                      "resource_state": 1
+                    },
+                    "athlete": {
+                      "id": 134815,
+                      "resource_state": 1
+                    },
+                    "elapsed_time": 1573,
+                    "moving_time": 1569,
+                    "start_date": "2018-02-16T14:52:54Z",
+                    "start_date_local": "2018-02-16T06:52:54Z",
+                    "distance": 8046.72,
+                    "start_index": 0,
+                    "end_index": 1570,
+                    "total_elevation_gain": 276,
+                    "average_speed": 5.12,
+                    "max_speed": 9.5,
+                    "average_cadence": 78.6,
+                    "device_watts": true,
+                    "average_watts": 233.1,
+                    "lap_index": 1,
+                    "split": 1
+                  }
+                ],
+                "gear": {
+                  "id": "b12345678987654321",
+                  "primary": true,
+                  "name": "Tarmac",
+                  "resource_state": 2,
+                  "distance": 32547610
+                },
+                "partner_brand_tag": null,
+                "photos": {
+                  "primary": {
+                    "id": null,
+                    "unique_id": "3FDGKL3-204E-4867-9E8D-89FC79EAAE17",
+                    "urls": {
+                      "100": "https://dgtzuqphqg23d.cloudfront.net/Bv93zv5t_mr57v0wXFbY_JyvtucgmU5Ym6N9z_bKeUI-128x96.jpg",
+                      "600": "https://dgtzuqphqg23d.cloudfront.net/Bv93zv5t_mr57v0wXFbY_JyvtucgmU5Ym6N9z_bKeUI-768x576.jpg"
+                    },
+                    "source": 1
+                  },
+                  "use_primary_photo": true,
+                  "count": 2
+                },
+                "highlighted_kudosers": [
+                  {
+                    "destination_url": "strava://athletes/12345678987654321",
+                    "display_name": "Marianne V.",
+                    "avatar_url": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/12345678987654321/12345678987654321/3/medium.jpg",
+                    "show_name": true
+                  }
+                ],
+                "device_name": "Garmin Edge 1030",
+                "embed_token": "18e4615989b47dd4ff3dc711b0aa4502e4b311a9",
+                "segment_leaderboard_opt_out": false,
+                "leaderboard_opt_out": false
+              }
             }
           },
           "default": {
@@ -929,7 +1405,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Activities of the athlete.",
+            "description": "The authenticated athlete's activities",
             "schema": {
               "type": "array",
               "items": {
@@ -937,71 +1413,209 @@
               }
             },
             "examples": {
-              "application/json": [
-                {
-                  "id": 999582172,
+              "application/json": {
+                "id": 12345678987654321,
+                "resource_state": 3,
+                "external_id": "garmin_push_12345678987654321",
+                "upload_id": 98765432123456789,
+                "athlete": {
+                  "id": 134815,
+                  "resource_state": 1
+                },
+                "name": "Happy Friday",
+                "distance": 28099,
+                "moving_time": 4207,
+                "elapsed_time": 4410,
+                "total_elevation_gain": 516,
+                "type": "Ride",
+                "start_date": "2018-02-16T14:52:54Z",
+                "start_date_local": "2018-02-16T06:52:54Z",
+                "timezone": "(GMT-08:00) America/Los_Angeles",
+                "utc_offset": -28800,
+                "start_latlng": [
+                  37.83,
+                  -122.26
+                ],
+                "end_latlng": [
+                  37.83,
+                  -122.26
+                ],
+                "location_city": null,
+                "location_state": null,
+                "location_country": "United States",
+                "start_latitude": 37.83,
+                "start_longitude": -122.26,
+                "achievement_count": 0,
+                "kudos_count": 19,
+                "comment_count": 0,
+                "athlete_count": 1,
+                "photo_count": 0,
+                "map": {
+                  "id": "a1410355832",
+                  "polyline": "ki{eFvqfiVqAWQIGEEKAYJgBVqDJ{BHa@jAkNJw@Pw@V{APs@^aABQAOEQGKoJ_FuJkFqAo@{A}@sH{DiAs@Q]?WVy@`@oBt@_CB]KYMMkB{AQEI@WT{BlE{@zAQPI@ICsCqA_BcAeCmAaFmCqIoEcLeG}KcG}A}@cDaBiDsByAkAuBqBi@y@_@o@o@kB}BgIoA_EUkAMcACa@BeBBq@LaAJe@b@uA`@_AdBcD`@iAPq@RgALqAB{@EqAyAoOCy@AmCBmANqBLqAZkB\\iCPiBJwCCsASiCq@iD]eA]y@[i@w@mAa@i@k@g@kAw@i@Ya@Q]EWFMLa@~BYpAFNpA`Aj@n@X`@V`AHh@JfB@xAMvAGZGHIDIAWOEQNcC@sACYK[MSOMe@QKKKYOs@UYQISCQ?Q@WNo@r@OHGAGCKOQ_BU}@MQGG]Io@@c@FYNg@d@s@d@ODQAMOMaASs@_@a@SESAQDqBn@a@RO?KK?UBU\\kA@Y?WMo@Iy@GWQ_@WSSGg@AkABQB_Ap@_A^o@b@Q@o@IS@OHi@n@OFS?OI}@iAQMQGQC}@DOIIUK{@IUOMyBo@kASOKIQCa@L[|AgATWN[He@?QKw@FOPCh@Fx@l@TDLELKl@aAHIJEX@r@ZTDV@LENQVg@RkA@c@MeA?WFOPMf@Ej@Fj@@LGHKDM?_@_@iC?a@HKRIl@NT?FCHMFW?YEYGWQa@GYBiAIq@Gq@L_BHSHK|@WJETSLQZs@z@_A~@uA^U`@G\\CRB\\Tl@p@Th@JZ^bB`@lAHLXVLDP?LGFSKiDBo@d@wBVi@R]VYVE\\@`@Lh@Fh@CzAk@RSDQA]GYe@eAGWSiBAWBWBIJORK`@KPOPSTg@h@}Ad@o@F[E_@EGMKUGmAEYGMIMYKs@?a@J}@@_BD_@HQJMx@e@LKHKHWAo@UoAAWFmAH}@?w@C[YwAAc@HSNM|Ao@rA}@zAq@`@a@j@eAxAuBXQj@MXSR[b@gAFg@?YISOGaAHi@Xw@v@_@d@WRSFqARUHQJc@d@m@`A[VSFUBcAEU@WFULUPa@v@Y~@UrBc@dBI~@?l@P~ABt@N`HEjA]zAEp@@p@TrBCl@CTQb@k@dAg@jAU^KJYLK@k@A[Js@d@a@b@]RgBl@[FMAw@[]G]?m@D_@F]P[Vu@t@[TMF_@Do@E_@@q@P]PWZUZw@vAkAlAGJOj@IlAMd@OR{@p@a@d@sBpD]v@a@`Aa@n@]TODgBVk@Pe@^cBfBc@Rs@La@RSPm@|@wCpDS^Wp@QZML{@l@qBbCYd@k@lAIVCZBZNTr@`@RRHZANIZQPKDW@e@CaASU?I@YTKRQx@@\\VmALYRQLCL?v@P|@D\\GJEFKDM@OCa@COOYIGm@YMUCM@]JYr@uAx@kAt@}@jAeAPWbAkBj@s@bAiAz@oAj@m@VQlAc@VQ~@aA`Au@p@Q`AIv@MZORUV_@p@iB|AoCh@q@dAaANUNWH[N{AJ[^m@t@_Av@wA\\a@`@W`@In@Al@B^E`@Wl@u@\\[VQ\\K`@Eb@?R@dAZP@d@CRExAs@\\Yt@{@LG\\MjAATINOXo@d@kAl@_AHYBOCe@QiBCm@Fq@\\wADo@AyGEeBWuB@YHu@Tu@Lk@VcCTo@d@aA\\WJE`@G~@FP?VI\\U~@sANO`@SfAMj@U\\WjAsAXS`@UNENALBHFFL?^Ml@Uj@]b@q@RUJSPkChEc@XcAb@sA|@]PaA\\OJKNER?TDTNj@Jn@?p@OfC@ZR`B@VCV_@n@{@l@WbACv@OlABnAPl@LNNHbBBNBLFFJ@^GLg@x@i@|AMP[X}@XOJKPET?l@LhAFXp@fBDRCd@S\\_@Ps@PQ@}A]S?QDe@V]b@MR[fAKt@ErAF~CANILYDKGIKe@{@Yy@e@sB[gA[c@e@YUCU?WBUHUNQPq@`AiArAMV[^e@Zc@JQJKNMz@?r@Bb@PfAAfA@VVbADn@E`@KHSEe@SMAKDKFM\\^dDCh@m@LoAQ_@@MFOZLfBEl@QbASd@KLQBOAaAc@QAQ@QHc@v@ONMJOBOCg@c@]O[EMBKFGL?RHv@ARERGNe@h@{@h@WVGNDt@JLNFPFz@LdBf@f@PJNHPF`ADPJJJDl@I`@B^Tp@bALJNDNALIf@i@PGPCt@DNE`@Uv@[dAw@RITGRCtAARBPJLPJRZxB?VEX_@vAAR?RDNHJJBh@UnBm@h@IRDRJNNJPNbBFRJLLBLCzAmAd@Uf@Gf@?P@PFJNHPFTH`BDTHNJJJ@LG`@m@^YPER@RDPHNNJRLn@HRLN^VNPHTFX@\\UlDFb@FHh@NP@HKPsB?}ASkCQ{@[y@q@}@cA{@KOCQDa@t@{CFGJCf@Nl@ZtA~@r@p@`@h@rAxBd@rA\\fARdAPjANrB?f@AtBCd@QfBkAjJOlBChA?rBFrBNlBdAfKFzAC~@Iz@Mz@Sv@s@jBmAxBi@hAWt@Sv@Qx@O`BA`@?dAPfBVpAd@`BfBlFf@fBdA~Cr@pAz@fApBhBjAt@H?IL?FBFJLx@^lHvDvh@~XnElCbAd@pGhDbAb@nAr@`Ad@`GhDnBbAxCbBrWhNJJDPARGP_@t@Qh@]pAUtAoA`Ny@jJApBBNFLJFJBv@Hb@HBF?\\",
+                  "resource_state": 3,
+                  "summary_polyline": "ki{eFvqfiVsBmA`Feh@qg@iX`B}JeCcCqGjIq~@kf@cM{KeHeX`@_GdGkSeBiXtB}YuEkPwFyDeAzAe@pC~DfGc@bIOsGmCcEiD~@oBuEkFhBcBmDiEfAVuDiAuD}NnDaNiIlCyDD_CtJKv@wGhD]YyEzBo@g@uKxGmHpCGtEtI~AuLrHkAcAaIvEgH_EaDR_FpBuBg@sNxHqEtHgLoTpIiCzKNr[sB|Es\\`JyObYeMbGsMnPsAfDxAnD}DBu@bCx@{BbEEyAoD`AmChNoQzMoGhOwX|[yIzBeFKg[zAkIdU_LiHxK}HzEh@vM_BtBg@xGzDbCcF~GhArHaIfByAhLsDiJuC?_HbHd@nL_Cz@ZnEkDDy@hHwJLiCbIrNrIvN_EfAjDWlEnEiAfBxDlFkBfBtEfDaAzBvDKdFx@|@XgJmDsHhAgD`GfElEzOwBnYdBxXgGlSc@bGdHpW|HdJztBnhAgFxc@HnCvBdA"
+                },
+                "trainer": false,
+                "commute": false,
+                "manual": false,
+                "private": false,
+                "flagged": false,
+                "gear_id": "b12345678987654321",
+                "from_accepted_tag": false,
+                "average_speed": 6.679,
+                "max_speed": 18.5,
+                "average_cadence": 78.5,
+                "average_temp": 4,
+                "average_watts": 185.5,
+                "weighted_average_watts": 230,
+                "kilojoules": 780.5,
+                "device_watts": true,
+                "has_heartrate": false,
+                "max_watts": 743,
+                "elev_high": 446.6,
+                "elev_low": 17.2,
+                "pr_count": 0,
+                "total_photo_count": 2,
+                "has_kudoed": false,
+                "workout_type": 10,
+                "suffer_score": null,
+                "description": "",
+                "calories": 870.2,
+                "segment_efforts": [
+                  {
+                    "id": 12345678987654321,
+                    "resource_state": 2,
+                    "name": "Tunnel Rd.",
+                    "activity": {
+                      "id": 12345678987654321,
+                      "resource_state": 1
+                    },
+                    "athlete": {
+                      "id": 12345678987654321,
+                      "resource_state": 1
+                    },
+                    "elapsed_time": 2038,
+                    "moving_time": 2038,
+                    "start_date": "2018-02-16T14:56:25Z",
+                    "start_date_local": "2018-02-16T06:56:25Z",
+                    "distance": 9434.8,
+                    "start_index": 211,
+                    "end_index": 2246,
+                    "average_cadence": 78.6,
+                    "device_watts": true,
+                    "average_watts": 237.6,
+                    "segment": {
+                      "id": 673683,
+                      "resource_state": 2,
+                      "name": "Tunnel Rd.",
+                      "activity_type": "Ride",
+                      "distance": 9220.7,
+                      "average_grade": 4.2,
+                      "maximum_grade": 25.8,
+                      "elevation_high": 426.5,
+                      "elevation_low": 43.4,
+                      "start_latlng": [
+                        37.8346153,
+                        -122.2520872
+                      ],
+                      "end_latlng": [
+                        37.8476261,
+                        -122.2008944
+                      ],
+                      "start_latitude": 37.8346153,
+                      "start_longitude": -122.2520872,
+                      "end_latitude": 37.8476261,
+                      "end_longitude": -122.2008944,
+                      "climb_category": 3,
+                      "city": "Oakland",
+                      "state": "CA",
+                      "country": "United States",
+                      "private": false,
+                      "hazardous": false,
+                      "starred": false
+                    },
+                    "kom_rank": null,
+                    "pr_rank": null,
+                    "achievements": [],
+                    "hidden": false
+                  }
+                ],
+                "splits_metric": [
+                  {
+                    "distance": 1001.5,
+                    "elapsed_time": 141,
+                    "elevation_difference": 4.4,
+                    "moving_time": 141,
+                    "split": 1,
+                    "average_speed": 7.1,
+                    "pace_zone": 0
+                  }
+                ],
+                "laps": [
+                  {
+                    "id": 4479306946,
+                    "resource_state": 2,
+                    "name": "Lap 1",
+                    "activity": {
+                      "id": 1410355832,
+                      "resource_state": 1
+                    },
+                    "athlete": {
+                      "id": 134815,
+                      "resource_state": 1
+                    },
+                    "elapsed_time": 1573,
+                    "moving_time": 1569,
+                    "start_date": "2018-02-16T14:52:54Z",
+                    "start_date_local": "2018-02-16T06:52:54Z",
+                    "distance": 8046.72,
+                    "start_index": 0,
+                    "end_index": 1570,
+                    "total_elevation_gain": 276,
+                    "average_speed": 5.12,
+                    "max_speed": 9.5,
+                    "average_cadence": 78.6,
+                    "device_watts": true,
+                    "average_watts": 233.1,
+                    "lap_index": 1,
+                    "split": 1
+                  }
+                ],
+                "gear": {
+                  "id": "b12345678987654321",
+                  "primary": true,
+                  "name": "Tarmac",
                   "resource_state": 2,
-                  "external_id": "garmin_push_1747504801",
-                  "upload_id": 1101802971,
-                  "athlete": {
-                    "id": 136697,
-                    "resource_state": 1
+                  "distance": 32547610
+                },
+                "partner_brand_tag": null,
+                "photos": {
+                  "primary": {
+                    "id": null,
+                    "unique_id": "3FDGKL3-204E-4867-9E8D-89FC79EAAE17",
+                    "urls": {
+                      "100": "https://dgtzuqphqg23d.cloudfront.net/Bv93zv5t_mr57v0wXFbY_JyvtucgmU5Ym6N9z_bKeUI-128x96.jpg",
+                      "600": "https://dgtzuqphqg23d.cloudfront.net/Bv93zv5t_mr57v0wXFbY_JyvtucgmU5Ym6N9z_bKeUI-768x576.jpg"
+                    },
+                    "source": 1
                   },
-                  "name": "Jonathan Pon Memorial Ride 2017 Day 2",
-                  "distance": 122111,
-                  "moving_time": 18748,
-                  "elapsed_time": 25880,
-                  "total_elevation_gain": 1055,
-                  "type": "Ride",
-                  "start_date": "2017-05-21T13:35:33Z",
-                  "start_date_local": "2017-05-21T06:35:33Z",
-                  "timezone": "(GMT-08:00) America/Los_Angeles",
-                  "utc_offset": -25200,
-                  "start_latlng": [
-                    38.46,
-                    -123.05
-                  ],
-                  "end_latlng": [
-                    37.87,
-                    -122.5
-                  ],
-                  "location_city": null,
-                  "location_state": null,
-                  "location_country": "United States",
-                  "start_latitude": 38.46,
-                  "start_longitude": -123.05,
-                  "achievement_count": 22,
-                  "kudos_count": 35,
-                  "comment_count": 0,
-                  "athlete_count": 3,
-                  "photo_count": 0,
-                  "map": {
-                    "id": "a999582172",
-                    "summary_polyline": "}_wiFh{_nVxJaDiBmKbc@`RpEda@pb@~b@v_@xiAcF|l@gb@j`ABrg@~KfNxh@zLrPpSr`@yTvDjr@f`B_q@`@wMlJnC|h@sU`^wBdHaMx]d@lHuLcCcLxLq@nKoUlnA_]hDyIhi@mVf@wH|tAgd@zi@qn@vQee@rZoPvJgVjQtGrIsNnDxS~UsKpqAecBmFwn@bAun@wb@e\\wMiWcFcp@sOmUcX}N}Lya@qBsn@bCg[lOeQjj@uwBzMwuCvc@yM~HwYgVsc@kA}a@jp@{kCJqcC`Okm@pCqz@v|@_hCnYqaBlQ_g@fe@y_@b{@kEzo@cPzfAsdBhAw~AuDeg@{J}l@gYku@wCgd@xK{kB|vAq|Chq@yiBrc@sp@bFaqC~Xam@{IcHhMsc@p_@bRvMeB~cBw`AtT_Vfu@hu@~}@nd@nCsvBrLi}@mB}J``@y{@~oBmuCxqAa[fpAgDhdBnSz_ArTpJbM|zAin@xR_VxQzKrS`^fIp@bNmExa@uf@fEi`B`^{}@na@q]ta@FndA`c@~c@^`Nj]?jMlsAtl@bLiN`v@m@vRkZvQhJzGkGu@kOxk@uKvYiiAtt@ki@zZyDtNlCG`Jz^fDny@orAfUkRhSl@nt@rf@rs@fH|EjP`~@RfFcWjMyIn]~LtJqL~QH`WdJXpaAta@hGd|AsPxwAasBdc@m\\eHK",
-                    "resource_state": 2
-                  },
-                  "trainer": false,
-                  "commute": false,
-                  "manual": false,
-                  "private": false,
-                  "flagged": false,
-                  "gear_id": "b3123396",
-                  "average_speed": 6.513,
-                  "max_speed": 17.3,
-                  "average_temp": 26,
-                  "average_watts": 132.1,
-                  "kilojoules": 2476.6,
-                  "device_watts": false,
-                  "has_heartrate": false,
-                  "elev_high": 79.6,
-                  "elev_low": -9.6,
-                  "pr_count": 4,
-                  "total_photo_count": 0,
-                  "has_kudoed": false,
-                  "workout_type": 10,
-                  "suffer_score": null
-                }
-              ]
+                  "use_primary_photo": true,
+                  "count": 2
+                },
+                "highlighted_kudosers": [
+                  {
+                    "destination_url": "strava://athletes/12345678987654321",
+                    "display_name": "Marianne V.",
+                    "avatar_url": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/12345678987654321/12345678987654321/3/medium.jpg",
+                    "show_name": true
+                  }
+                ],
+                "device_name": "Garmin Edge 1030",
+                "embed_token": "18e4615989b47dd4ff3dc711b0aa4502e4b311a9",
+                "segment_leaderboard_opt_out": false,
+                "leaderboard_opt_out": false
+              }
             }
           },
           "default": {
@@ -1039,6 +1653,38 @@
               "items": {
                 "$ref": "{{reference_prefix}}/lap.json#/Lap"
               }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "id": 12345678987654321,
+                  "resource_state": 2,
+                  "name": "Lap 1",
+                  "activity": {
+                    "id": 12345678987654321,
+                    "resource_state": 1
+                  },
+                  "athlete": {
+                    "id": 12345678987654321,
+                    "resource_state": 1
+                  },
+                  "elapsed_time": 1691,
+                  "moving_time": 1587,
+                  "start_date": "2018-02-08T14:13:37Z",
+                  "start_date_local": "2018-02-08T06:13:37Z",
+                  "distance": 8046.72,
+                  "start_index": 0,
+                  "end_index": 1590,
+                  "total_elevation_gain": 270,
+                  "average_speed": 4.76,
+                  "max_speed": 9.4,
+                  "average_cadence": 79,
+                  "device_watts": true,
+                  "average_watts": 228.2,
+                  "lap_index": 1,
+                  "split": 1
+                }
+              ]
             }
           },
           "default": {
@@ -1054,7 +1700,7 @@
       "get": {
         "operationId": "getZonesByActivityId",
         "summary": "Get Activity Zones",
-        "description": "Returns the zones of an activity identified by an identifier.",
+        "description": "Premium only. Returns the zones of a given activity.",
         "parameters": [
           {
             "name": "id",
@@ -1090,7 +1736,7 @@
       "get": {
         "operationId": "getCommentsByActivityId",
         "summary": "List Activity Comments",
-        "description": "Returns the comments of an activity identified by an identifier.",
+        "description": "Returns the comments on the given activity.",
         "parameters": [
           {
             "name": "id",
@@ -1118,6 +1764,38 @@
               "items": {
                 "$ref": "{{reference_prefix}}/comment.json#/Comment"
               }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "id": 12345678987654321,
+                  "activity_id": 12345678987654321,
+                  "post_id": null,
+                  "resource_state": 2,
+                  "text": "Good job and keep the cat pictures coming!",
+                  "mentions_metadata": null,
+                  "created_at": "2018-02-08T19:25:39Z",
+                  "athlete": {
+                    "id": 12345678987654321,
+                    "username": "psagan",
+                    "resource_state": 2,
+                    "firstname": "Peter",
+                    "lastname": "Sagan",
+                    "city": "South Orange",
+                    "state": "New Jersey",
+                    "country": "United States",
+                    "sex": "F",
+                    "premium": true,
+                    "created_at": "2011-12-20T14:21:57Z",
+                    "updated_at": "2018-02-12T20:18:25Z",
+                    "badge_type_id": 4,
+                    "profile_medium": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/123456789/123456789/2/medium.jpg",
+                    "profile": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/123456789/123456789/2/large.jpg",
+                    "friend": "accepted",
+                    "follower": "accepted"
+                  }
+                }
+              ]
             }
           },
           "default": {
@@ -1160,6 +1838,29 @@
               "items": {
                 "$ref": "{{reference_prefix}}/athlete.json#/SummaryAthlete"
               }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "id": 1234556678987654321,
+                  "username": "psagan",
+                  "resource_state": 2,
+                  "firstname": "Peter",
+                  "lastname": "Sagan",
+                  "city": "Norwich",
+                  "state": "Vermont",
+                  "country": "United States",
+                  "sex": "M",
+                  "premium": true,
+                  "created_at": "2008-01-01T17:44:00Z",
+                  "updated_at": "2018-01-30T07:00:32Z",
+                  "badge_type_id": 4,
+                  "profile_medium": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/123456789/123456789/1/medium.jpg",
+                  "profile": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/123456789/123456789/1/large.jpg",
+                  "friend": "accepted",
+                  "follower": "accepted"
+                }
+              ]
             }
           },
           "default": {
@@ -1266,7 +1967,7 @@
             },
             "examples": {
               "application/json": {
-                "id": 123456789,
+                "id": 12345678987654321,
                 "username": "psagan",
                 "resource_state": 2,
                 "firstname": "Peter",
@@ -1334,7 +2035,7 @@
             "examples": {
               "application/json": [
                 {
-                  "id": 123456789,
+                  "id": 12345678987654321,
                   "username": "psagan",
                   "resource_state": 2,
                   "firstname": "Peter",
@@ -1399,12 +2100,12 @@
             "examples": {
               "application/json": [
                 {
-                  "id": 123456789,
+                  "id": 12345678987654321,
                   "resource_state": 2,
                   "external_id": "garmin_push_123456789",
                   "upload_id": 987654321,
                   "athlete": {
-                    "id": 123456789,
+                    "id": 12345678987654321,
                     "username": "psagan",
                     "resource_state": 2,
                     "firstname": "Peter",


### PR DESCRIPTION
This is the last one.... Note that the detailed activity representations are identical for a couple of the endpoints -- I just copied them, so no need to re-review the detailed activity responses.

Adds sample responses and cleans up the documentation for each of the activities endpoints. I'm primarily looking for english typos and data sanitization in review.

Completes [API-698](https://strava.atlassian.net/browse/API-698)