### PR TITLE
Updated response for segments/{id}/leaderboard endpoint

### DIFF
--- a/swagger/swagger.json.mustache
+++ b/swagger/swagger.json.mustache
@@ -693,29 +693,19 @@
             },
             "examples": {
               "application/json": {
-                "effort_count": 30623,
-                "entry_count": 30623,
+                "effort_count": 30756,
+                "entry_count": 30756,
                 "kom_type": "kom",
                 "entries": [
                   {
-                    "athlete_name": "Peter Sagan",
-                    "athlete_id": 123456789,
-                    "athlete_gender": "M",
-                    "average_hr": null,
-                    "average_watts": 496.8,
-                    "distance": 2659.2,
+                    "athlete_name": "Peter S.",
                     "elapsed_time": 346,
                     "moving_time": 346,
-                    "start_date": "1993-04-11T15:37:43Z",
-                    "start_date_local": "1993-04-11T07:37:43Z",
-                    "activity_id": 123456789,
-                    "effort_id": 12345678987654321,
-                    "rank": 1,
-                    "neighborhood_index": 0,
-                    "athlete_profile": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/123456789/123456789/2/large.jpg"
+                    "start_date": "1993-04-03T15:37:43Z",
+                    "start_date_local": "1993-04-03T07:37:43Z",
+                    "rank": 1
                   }
-                ],
-                "neighborhood_count": 2
+                ]
               }
             }
           },


### PR DESCRIPTION
This PR updates the sample response for the segments/{id}/leaderboard endpoint to reflect what's actually returned by the endpoint.