### PR TITLE
[API-733] Manual Activity missing from developers.strava.com

### DIFF
--- a/swagger/swagger.json.mustache
+++ b/swagger/swagger.json.mustache
@@ -103,53 +103,53 @@
               "$ref": "{{reference_prefix}}/athlete.json#/DetailedAthlete"
             },
             "examples": {
-                "application/json": {
-                     "id": 1234567890987654321,
-                     "username": "marianne_v",
-                     "resource_state": 3,
-                     "firstname": "Marianne",
-                     "lastname": "V.",
-                     "city": "San Francisco",
-                     "state": "CA",
-                     "country": "US",
-                     "sex": "F",
-                     "premium": true,
-                     "created_at": "2017-11-14T02:30:05Z",
-                     "updated_at": "2018-02-06T19:32:20Z",
-                     "badge_type_id": 4,
-                     "profile_medium": "https://xxxxxx.cloudfront.net/pictures/athletes/123456789/123456789/2/medium.jpg",
-                     "profile": "https://xxxxx.cloudfront.net/pictures/athletes/123456789/123456789/2/large.jpg",
-                     "friend": null,
-                     "follower": null,
-                     "email": "mv@abc.com",
-                     "follower_count": 5,
-                     "friend_count": 5,
-                     "mutual_friend_count": 0,
-                     "athlete_type": 1,
-                     "date_preference": "%m/%d/%Y",
-                     "measurement_preference": "feet",
-                     "clubs": [],
-                     "ftp": null,
-                     "weight": 0,
-                     "bikes": [
-                     {
-                        "id": "b12345678987655",
-                        "primary": true,
-                        "name": "EMC",
-                        "resource_state": 2,
-                        "distance": 0
-                     }
-                     ],
-                     "shoes": [
-                     {
-                        "id": "g12345678987655",
-                        "primary": true,
-                        "name": "adidas",
-                        "resource_state": 2,
-                        "distance": 4904
-                     }
-                     ]
-                }
+              "application/json": {
+                "id": 1234567890987654321,
+                "username": "marianne_v",
+                "resource_state": 3,
+                "firstname": "Marianne",
+                "lastname": "V.",
+                "city": "San Francisco",
+                "state": "CA",
+                "country": "US",
+                "sex": "F",
+                "premium": true,
+                "created_at": "2017-11-14T02:30:05Z",
+                "updated_at": "2018-02-06T19:32:20Z",
+                "badge_type_id": 4,
+                "profile_medium": "https://xxxxxx.cloudfront.net/pictures/athletes/123456789/123456789/2/medium.jpg",
+                "profile": "https://xxxxx.cloudfront.net/pictures/athletes/123456789/123456789/2/large.jpg",
+                "friend": null,
+                "follower": null,
+                "email": "mv@abc.com",
+                "follower_count": 5,
+                "friend_count": 5,
+                "mutual_friend_count": 0,
+                "athlete_type": 1,
+                "date_preference": "%m/%d/%Y",
+                "measurement_preference": "feet",
+                "clubs": [],
+                "ftp": null,
+                "weight": 0,
+                "bikes": [
+                  {
+                    "id": "b12345678987655",
+                    "primary": true,
+                    "name": "EMC",
+                    "resource_state": 2,
+                    "distance": 0
+                  }
+                ],
+                "shoes": [
+                  {
+                    "id": "g12345678987655",
+                    "primary": true,
+                    "name": "adidas",
+                    "resource_state": 2,
+                    "distance": 4904
+                  }
+                ]
+              }
             }
           },
           "default": {
@@ -185,53 +185,53 @@
               "$ref": "{{reference_prefix}}/athlete.json#/DetailedAthlete"
             },
             "examples": {
-                "application/json": {
-                    "id": 12345678987655098765444,
-                    "username": "marianne_v",
-                    "resource_state": 3,
-                    "firstname": "Marianne",
-                    "lastname": "V.",
-                    "city": "San Francisco",
-                    "state": "CA",
-                    "country": "US",
-                    "sex": "F",
-                    "premium": true,
-                    "created_at": "2017-11-14T02:30:05Z",
-                    "updated_at": "2018-02-06T19:32:20Z",
-                    "badge_type_id": 4,
-                    "profile_medium": "https://xxxxxx.cloudfront.net/pictures/athletes/1234567898765509876/1234567898765509876/2/medium.jpg",
-                    "profile": "https://xxxxx.cloudfront.net/pictures/athletes/1234567898765509876/1234567898765509876/2/large.jpg",
-                    "friend": null,
-                    "follower": null,
-                    "email": "mv@abc.com",
-                    "follower_count": 5,
-                    "friend_count": 5,
-                    "mutual_friend_count": 0,
-                    "athlete_type": 1,
-                    "date_preference": "%m/%d/%Y",
-                    "measurement_preference": "feet",
-                    "clubs": [],
-                    "ftp": null,
-                    "weight": 0,
-                    "bikes": [
-                    {
-                        "id": "b1234567898765509876",
-                        "primary": true,
-                        "name": "EMC",
-                        "resource_state": 2,
-                        "distance": 0
-                    }
-                    ],
-                    "shoes": [
-                    {
-                       "id": "g1234567898765509876",
-                       "primary": true,
-                       "name": "adidas",
-                       "resource_state": 2,
-                       "distance": 4904
-                    }
-                    ]
-                }
+              "application/json": {
+                "id": 12345678987655098765444,
+                "username": "marianne_v",
+                "resource_state": 3,
+                "firstname": "Marianne",
+                "lastname": "V.",
+                "city": "San Francisco",
+                "state": "CA",
+                "country": "US",
+                "sex": "F",
+                "premium": true,
+                "created_at": "2017-11-14T02:30:05Z",
+                "updated_at": "2018-02-06T19:32:20Z",
+                "badge_type_id": 4,
+                "profile_medium": "https://xxxxxx.cloudfront.net/pictures/athletes/1234567898765509876/1234567898765509876/2/medium.jpg",
+                "profile": "https://xxxxx.cloudfront.net/pictures/athletes/1234567898765509876/1234567898765509876/2/large.jpg",
+                "friend": null,
+                "follower": null,
+                "email": "mv@abc.com",
+                "follower_count": 5,
+                "friend_count": 5,
+                "mutual_friend_count": 0,
+                "athlete_type": 1,
+                "date_preference": "%m/%d/%Y",
+                "measurement_preference": "feet",
+                "clubs": [],
+                "ftp": null,
+                "weight": 0,
+                "bikes": [
+                  {
+                    "id": "b1234567898765509876",
+                    "primary": true,
+                    "name": "EMC",
+                    "resource_state": 2,
+                    "distance": 0
+                  }
+                ],
+                "shoes": [
+                  {
+                    "id": "g1234567898765509876",
+                    "primary": true,
+                    "name": "adidas",
+                    "resource_state": 2,
+                    "distance": 4904
+                  }
+                ]
+              }
             }
           },
           "default": {
@@ -751,63 +751,63 @@
               }
             },
             "examples": {
-                "application/json": [
-                    {
-                         "id": 123456789,
-                         "resource_state": 2,
-                         "name": "Alpe d'Huez",
-                         "activity": {
-                         	"id": 1234567890,
-                            "resource_state": 1
-                         },
-                         "athlete": {
-                         	"id": 123445678689,
-                            "resource_state": 1
-                         },
-                         "elapsed_time": 1657,
-                         "moving_time": 1642,
-                         "start_date": "2007-09-15T08:15:29Z",
-                         "start_date_local": "2007-09-15T09:15:29Z",
-                         "distance": 6148.92,
-                         "start_index": 1102,
-                         "end_index": 1366,
-                         "device_watts": false,
-                         "average_watts": 220.2,
-                         "segment": {
-                            "id": 788127,
-                            "resource_state": 2,
-                            "name": "Alpe d'Huez",
-                            "activity_type": "Ride",
-                            "distance": 6297.46,
-                            "average_grade": 4.8,
-                            "maximum_grade": 16.3,
-                            "elevation_high": 416,
-                            "elevation_low": 104.6,
-                            "start_latlng": [
-                                52.98501000581467,
-                                 -3.1869720001197367
-                            ],
-                            "end_latlng": [
-                                53.02204074375785,
-                                -3.2039630001245737
-                            ],
-                            "start_latitude": 82.9858888581467,
-                            "start_longitude": -3.1869788881197367,
-                            "end_latitude": 43.022040343380785,
-                            "end_longitude": -13.2039639991245737,
-                            "climb_category": 2,
-                            "city": "Le Bourg D'Oisans",
-                            "state": "RA",
-                            "country": "France",
-                            "private": false,
-                            "hazardous": false,
-                            "starred": false
-                         },
-                         "kom_rank": null,
-                         "pr_rank": null,
-                         "achievements": []
-                    }
-                ]
+              "application/json": [
+                {
+                  "id": 123456789,
+                  "resource_state": 2,
+                  "name": "Alpe d'Huez",
+                  "activity": {
+                    "id": 1234567890,
+                    "resource_state": 1
+                  },
+                  "athlete": {
+                    "id": 123445678689,
+                    "resource_state": 1
+                  },
+                  "elapsed_time": 1657,
+                  "moving_time": 1642,
+                  "start_date": "2007-09-15T08:15:29Z",
+                  "start_date_local": "2007-09-15T09:15:29Z",
+                  "distance": 6148.92,
+                  "start_index": 1102,
+                  "end_index": 1366,
+                  "device_watts": false,
+                  "average_watts": 220.2,
+                  "segment": {
+                    "id": 788127,
+                    "resource_state": 2,
+                    "name": "Alpe d'Huez",
+                    "activity_type": "Ride",
+                    "distance": 6297.46,
+                    "average_grade": 4.8,
+                    "maximum_grade": 16.3,
+                    "elevation_high": 416,
+                    "elevation_low": 104.6,
+                    "start_latlng": [
+                      52.98501000581467,
+                      -3.1869720001197367
+                    ],
+                    "end_latlng": [
+                      53.02204074375785,
+                      -3.2039630001245737
+                    ],
+                    "start_latitude": 82.9858888581467,
+                    "start_longitude": -3.1869788881197367,
+                    "end_latitude": 43.022040343380785,
+                    "end_longitude": -13.2039639991245737,
+                    "climb_category": 2,
+                    "city": "Le Bourg D'Oisans",
+                    "state": "RA",
+                    "country": "France",
+                    "private": false,
+                    "hazardous": false,
+                    "starred": false
+                  },
+                  "kom_rank": null,
+                  "pr_rank": null,
+                  "achievements": []
+                }
+              ]
             }
           },
           "default": {
@@ -936,64 +936,64 @@
               "$ref": "{{reference_prefix}}/segment_effort.json#/DetailedSegmentEffort"
             },
             "examples": {
-                "application/json": {
-                    "id": 1234556789,
-                    "resource_state": 3,
-                    "name": "Alpe d'Huez",
-                    "activity": {
-                        "id": 3454504,
-                        "resource_state": 1
-                    },
-                    "athlete": {
-                        "id": 54321,
-                        "resource_state": 1
-                    },
-                    "elapsed_time": 381,
-                    "moving_time": 340,
-                    "start_date": "2018-02-12T16:12:41Z",
-                    "start_date_local": "2018-02-12T08:12:41Z",
-                    "distance": 83,
-                    "start_index": 65,
-                    "end_index": 83,
-                    "segment": {
-                        "id": 63450,
-                        "resource_state": 2,
-                        "name": "Alpe d'Huez",
-                        "activity_type": "Run",
-                        "distance": 780.35,
-                        "average_grade": -0.5,
-                        "maximum_grade": 0,
-                        "elevation_high": 21,
-                        "elevation_low": 17.2,
-                        "start_latlng": [
-                            37.808407654682,
-                            -122.426682919323
-                        ],
-                        "end_latlng": [
-                            37.808297909724,
-                            -122.421324329674
-                        ],
-                        "start_latitude": 37.80840654682,
-                        "start_longitude": -122.45682919323,
-                        "end_latitude": 37.80829000979624,
-                        "end_longitude": -122.42000324329674,
-                        "climb_category": 0,
-                        "city": "San Francisco",
-                        "state": "CA",
-                        "country": "United States",
-                        "private": false,
-                        "hazardous": false,
-                        "starred": false
-                    },
-                    "kom_rank": null,
-                    "pr_rank": null,
-                    "achievements": [],
-                    "athlete_segment_stats": {
-                        "pr_elapsed_time": 212,
-                        "pr_date": "2015-02-12",
-                        "effort_count": 149
-                    }
+              "application/json": {
+                "id": 1234556789,
+                "resource_state": 3,
+                "name": "Alpe d'Huez",
+                "activity": {
+                  "id": 3454504,
+                  "resource_state": 1
+                },
+                "athlete": {
+                  "id": 54321,
+                  "resource_state": 1
+                },
+                "elapsed_time": 381,
+                "moving_time": 340,
+                "start_date": "2018-02-12T16:12:41Z",
+                "start_date_local": "2018-02-12T08:12:41Z",
+                "distance": 83,
+                "start_index": 65,
+                "end_index": 83,
+                "segment": {
+                  "id": 63450,
+                  "resource_state": 2,
+                  "name": "Alpe d'Huez",
+                  "activity_type": "Run",
+                  "distance": 780.35,
+                  "average_grade": -0.5,
+                  "maximum_grade": 0,
+                  "elevation_high": 21,
+                  "elevation_low": 17.2,
+                  "start_latlng": [
+                    37.808407654682,
+                    -122.426682919323
+                  ],
+                  "end_latlng": [
+                    37.808297909724,
+                    -122.421324329674
+                  ],
+                  "start_latitude": 37.80840654682,
+                  "start_longitude": -122.45682919323,
+                  "end_latitude": 37.80829000979624,
+                  "end_longitude": -122.42000324329674,
+                  "climb_category": 0,
+                  "city": "San Francisco",
+                  "state": "CA",
+                  "country": "United States",
+                  "private": false,
+                  "hazardous": false,
+                  "starred": false
+                },
+                "kom_rank": null,
+                "pr_rank": null,
+                "achievements": [],
+                "athlete_segment_stats": {
+                  "pr_elapsed_time": 212,
+                  "pr_date": "2015-02-12",
+                  "effort_count": 149
                 }
+              }
             }
           },
           "default": {
@@ -1073,7 +1073,163 @@
         }
       }
     },
-    "/activities/{id}": {
+    "/activities": {
+      "post": {
+        "operationId": "createActivity",
+        "summary": "Create an Activity",
+        "description": "Creates a manual activity for an athlete. Requires write permissions, as requested during the authorization process.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "formData",
+            "description": "The name of the activity.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "type",
+            "in": "formData",
+            "description": "Type of activity. For example - Run, Ride etc.",
+            "type": "string",
+            "required": true
+          },
+          {
+            "name": "start_date_local",
+            "in": "formData",
+            "description": "ISO 8601 formatted date time.",
+            "type": "datetime",
+            "required": true
+          },
+          {
+            "name": "elapsed_time",
+            "in": "formData",
+            "description": "In seconds.",
+            "type": "integer",
+            "required": true
+          },
+          {
+            "name": "description",
+            "in": "formData",
+            "description": "Description of the activity.",
+            "type": "string",
+            "required": false
+          },
+          {
+            "name": "distance",
+            "in": "formData",
+            "description": "In meters.",
+            "type": "float",
+            "required": false
+          },
+          {
+            "name": "private",
+            "in": "formData",
+            "description": "set to 1 to mark the resulting activity as private, ‘view_private’ permissions will be necessary to view the activity. If not specified, set according to the athlete’s privacy setting (recommended).",
+            "type": "integer",
+            "required": false
+          },
+          {
+            "name": "trainer",
+            "in": "formData",
+            "description": "Set to 1 to mark as a trainer activity.",
+            "type": "integer",
+            "required": false
+          },
+          {
+            "name": "photo_ids",
+            "in": "formData",
+            "description": "List of native photo ids to attach to the activity.",
+            "type": "string[]",
+            "required": false
+          },
+          {
+            "name": "commute",
+            "in": "formData",
+            "description": "Set to 1 to mark as commute.",
+            "type": "integer",
+            "required": false
+          }
+        ],
+        "tags": [
+          "Activities"
+        ],
+        "responses": {
+          "201": {
+            "description": "The activity's detailed representation.",
+            "schema": {
+              "$ref": "{{reference_prefix}}/activity.json#/DetailedActivity"
+            },
+            "examples": {
+              "application/json": {
+                "id": 123456778928065,
+                "resource_state": 3,
+                "external_id": null,
+                "upload_id": null,
+                "athlete": {
+                  "id": 12343545645788,
+                  "resource_state": 1
+                },
+                "name": "Chill Day",
+                "distance": 0,
+                "moving_time": 18373,
+                "elapsed_time": 18373,
+                "total_elevation_gain": 0,
+                "type": "Ride",
+                "start_date": "2018-02-20T18:02:13Z",
+                "start_date_local": "2018-02-20T10:02:13Z",
+                "timezone": "(GMT-08:00) America/Los_Angeles",
+                "utc_offset": -28800,
+                "start_latlng": null,
+                "end_latlng": null,
+                "location_city": null,
+                "location_state": null,
+                "location_country": "",
+                "start_latitude": null,
+                "start_longitude": null,
+                "achievement_count": 0,
+                "kudos_count": 0,
+                "comment_count": 0,
+                "athlete_count": 1,
+                "photo_count": 0,
+                "map": {
+                  "id": "a12345678908766",
+                  "polyline": null,
+                  "resource_state": 3
+                },
+                "trainer": false,
+                "commute": false,
+                "manual": true,
+                "private": false,
+                "flagged": false,
+                "gear_id": "b453542543",
+                "from_accepted_tag": null,
+                "average_speed": 0,
+                "max_speed": 0,
+                "device_watts": false,
+                "has_heartrate": false,
+                "pr_count": 0,
+                "total_photo_count": 0,
+                "has_kudoed": false,
+                "workout_type": null,
+                "description": null,
+                "calories": 0,
+                "segment_efforts": [],
+                "partner_brand_tag": null,
+                "highlighted_kudosers": [],
+                "embed_token": "e65c2a814xxxxxxxxxxxxxxxxx68",
+                "segment_leaderboard_opt_out": false,
+                "leaderboard_opt_out": false
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error.",
+            "schema": {
+              "$ref": "{{reference_prefix}}/fault.json#/Fault"
+            }
+          }
+        }
+      },
       "get": {
         "operationId": "getActivityById",
         "summary": "Get Activity",
@@ -2542,16 +2698,16 @@
               "$ref": "{{reference_prefix}}/gear.json#/DetailedGear"
             },
             "examples": {
-                "application/json": {
-                    "id": "b1231",
-                    "primary": false,
-                    "resource_state": 3,
-                    "distance": 388206,
-                    "brand_name": "BMC",
-                    "model_name": "Teammachine",
-                    "frame_type": 3,
-                    "description": "My Bike."
-                }
+              "application/json": {
+                "id": "b1231",
+                "primary": false,
+                "resource_state": 3,
+                "distance": 388206,
+                "brand_name": "BMC",
+                "model_name": "Teammachine",
+                "frame_type": 3,
+                "description": "My Bike."
+              }
             }
           },
           "default": {


### PR DESCRIPTION
Added the Create Activity endpoint documentation for manual activities. Stubbed out all the identifying information (hopefully)