### PR TITLE
API-817 Star/Unstar segment API (broken) documentation

### DIFF
--- a/swagger/swagger.json.mustache
+++ b/swagger/swagger.json.mustache
@@ -502,7 +502,7 @@
       "put": {
         "operationId": "starSegment",
         "summary": "Star Segment",
-        "description": "Stars the given segment for the authenticated athlete.",
+        "description": "Stars/Unstars the given segment for the authenticated athlete.",
         "parameters": [
           {
             "name": "id",
@@ -511,6 +511,14 @@
             "required": true,
             "type": "integer",
             "format": "int64"
+          },
+          {
+            "name": "starred",
+            "in": "formData",
+            "description": "If true, star the segment; if false, unstar the segment.",
+            "type": "boolean",
+            "required": true,
+            "default": false
           }
         ],
         "tags": [


### PR DESCRIPTION
JIRA - https://strava.atlassian.net/browse/API-817
#### Background 
Two of the API users have notified us that the star/unstar API is broken
https://groups.google.com/forum/#!topic/strava-api/wXq2shpYWeU
Turns out, the API requires a `starred` field to star a segment. The absence of that parameter results to technically `unstarring` the segment. The API endpoint works fine but the cause of the confusion was the missing piece in the documentation. This PR fixes the documentation.