### PR TITLE
Displaying better information

### DIFF
--- a/codegen/src/main/resources/strava-html/param.mustache
+++ b/codegen/src/main/resources/strava-html/param.mustache
@@ -1,7 +1,7 @@
 <tr>
   <td width="200px">
     {{#isBodyParam}}
-      &lt;Not a named parameter>
+      &lt;Parameter Name>
     {{/isBodyParam}}
     {{^isBodyParam}}
       <span class="parameter-name">{{baseName}}</span>

--- a/swagger/activity.json.mustache
+++ b/swagger/activity.json.mustache
@@ -244,6 +244,10 @@
       "private": {
         "type": "boolean",
         "description": "Whether this activity is private"
+      },
+      "gear_id": {
+        "type": "string",
+        "description": "Identifier for the gear associated with the activity. ‘none’ clears gear from activity"
       }
     }
   }


### PR DESCRIPTION
Let me explain with screenshots.

Before : 
![image](https://user-images.githubusercontent.com/35939898/40137247-c91140da-58fe-11e8-947c-05daedaa2195.png)

After : 
![image](https://user-images.githubusercontent.com/35939898/40137314-e6fe9bd8-58fe-11e8-8902-8bde1ad34792.png)

Is this better? Also, please let me know if this is going to break any of the swagger built code. I dont think so but a confirmation would be great.