### PR TITLE
[API-861] Add power related fields to summary and detailed activity

### DIFF
--- a/swagger/activity.json.mustache
+++ b/swagger/activity.json.mustache
@@ -204,6 +204,28 @@
           "has_kudoed": {
             "type": "boolean",
             "description": "Whether the logged-in athlete has kudoed this activity"
+          },
+          "kilojoules": {
+            "type": "number",
+            "format": "float",
+            "description": "The total work done in kilojoules during this activity. Rides only"
+          },
+          "average_watts": {
+            "type": "number",
+            "format": "float",
+            "description": "Average power output in watts during this activity. Rides only"
+          },
+          "device_watts": {
+            "type": "boolean",
+            "description": "Whether the watts are from a power meter, false if estimated"
+          },
+          "max_watts": {
+            "type": "integer",
+            "description": "Rides with power meter data only"
+          },
+          "weighted_average_watts": {
+            "type": "integer",
+            "description": "Similar to Normalized Power. Rides with power meter data only"
           }
         }
       }


### PR DESCRIPTION
These fields are already returned in the API, but not documented in this
new doc, porting them over from the old doc.

While I'm in the zone writing api doc, here is another one for you all. Debating if I should add this to the changelog... it's not new for the api, but was never documented in the swagger version of the api doc 🤷‍♀️ 